### PR TITLE
Roomier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# musicbox
+# Musicbox
+
+## Things You Need First
+
+- [nvm](https://github.com/nvm-sh/nvm)
+  - `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
+`
+- [node](https://nodejs.org/en/)
+  - `nvm install`
+
+## Setup
+
+We are not currently using Docker for this project, so you'll have to install some things yourself.  Do like:
+
+1. `nvm use`
+2. `npm install`
+3. `npm start`
+
+Now your dev server should be up and running.  It opens a tab for you automatically!  It hot-reloads!
+
+## Commands
+
+- `npm start`
+  - Runs the hot-reload development server
+- `npm tsc`
+  - Runs the typescript compiler.  Note that we're using [Babel](https://babeljs.io/) to transpile typescript to javascript, so there's **no type checking at runtime**.  This is both good and bad because your dev server will not explode if you make a type error while developing -- but you'll want to run this occassionally to make sure everything is hunky-dory!
+- `npm run lint:fix`
+  - Runs [ESLint](https://eslint.org/), including [Prettier](https://prettier.io/). Attempts to correct any errors you make.
+
+## Contributing
+
+1.  We do not currently have a build server setup, so please run the typescript compiler and linter to make sure everything is a-okay.
+2.  We haven't started writing tests yet, so I guess don't worry too much about that.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,17 +26,17 @@ const App: React.FC = () => {
   })
 
   useEffect(() => {
-    if(!token) {
+    if (!token) {
       return
     }
 
-    awaitWebsocket(token).then((websocket) => {
+    awaitWebsocket(token).then(websocket => {
       const socketClient = new Client(websocket, { debug: true })
       socketClient.bind()
 
       setWebsocketClient(socketClient)
     })
-  }, [token]);
+  }, [token])
 
   return (
     <ApolloProvider client={apolloClient}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useState, useEffect } from 'react'
 import { ApolloProvider } from '@apollo/react-hooks'
 import ApolloClient from 'apollo-boost'
-import Router from './Router'
+import Router from 'Router'
 
-import { Client, awaitWebsocket } from './lib/WebsocketClient/client'
+import { Client, awaitWebsocket } from 'lib/WebsocketClient/client'
 
 type AuthContext = {
   token: string

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import gql from 'graphql-tag'
 import { useQuery } from '@apollo/react-hooks'
 
-import RoomSelector from './components/RoomSelector'
-import TeamSelector from './components/TeamSelector'
+import RoomSelector from 'components/RoomSelector'
+import TeamSelector from 'components/TeamSelector'
 
-import { UserType } from './lib/apiTypes'
+import { UserType } from 'lib/apiTypes'
 
 type UserQuery = {
   user: UserType

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
-import { AuthContext } from './App'
+import { AuthContext } from 'App'
 
 type SetFromEvent = (changeFn: (v: string) => void) => (ev: React.ChangeEvent<HTMLInputElement>) => void
 const setFromEvent: SetFromEvent = changeFn => ev => changeFn(ev.target.value)

--- a/src/Room.tsx
+++ b/src/Room.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react'
 import gql from 'graphql-tag'
-import { useMutation, useQuery } from '@apollo/react-hooks'
+import { useMutation } from '@apollo/react-hooks'
 import { useParams } from 'react-router-dom'
 
 import { WebsocketContext } from 'App'

--- a/src/Room.tsx
+++ b/src/Room.tsx
@@ -23,20 +23,24 @@ const Room: React.FC = () => {
 
   useEffect(() => {
     roomActivate({ variables: { roomId: id } })
-  }, [id])
+  }, [id, roomActivate])
 
   useEffect(() => {
-    if(!active || !websocket) {
+    if (!active || !websocket) {
       return
     }
 
-    return websocket.subscribeToUsers((room) => setUsers(room.users))
-  }, [active])
+    return websocket.subscribeToUsers(room => setUsers(room.users))
+  }, [active, websocket])
 
   return (
     <>
       <p>users</p>
-      <ul>{users.map(u => <li key={u.id}>{u.email}</li>)}</ul>
+      <ul>
+        {users.map(u => (
+          <li key={u.id}>{u.email}</li>
+        ))}
+      </ul>
     </>
   )
 }

--- a/src/Room.tsx
+++ b/src/Room.tsx
@@ -3,8 +3,8 @@ import gql from 'graphql-tag'
 import { useMutation, useQuery } from '@apollo/react-hooks'
 import { useParams } from 'react-router-dom'
 
-import { WebsocketContext } from './App'
-import { UserType } from './lib/apiTypes'
+import { WebsocketContext } from 'App'
+import { UserType } from 'lib/apiTypes'
 
 const ROOM_ACTIVATE = gql`
   mutation RoomActivate($roomId: ID!) {

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom'
-import { AuthContext } from './App'
+import { AuthContext } from 'App'
 
-import Login from './Login'
-import Home from './Home'
-import Room from './Room'
+import Login from 'Login'
+import Home from 'Home'
+import Room from 'Room'
 
 const Router: React.FC = () => {
   return (

--- a/src/components/RoomSelector.tsx
+++ b/src/components/RoomSelector.tsx
@@ -3,7 +3,7 @@ import gql from 'graphql-tag'
 import { useQuery } from '@apollo/react-hooks'
 import { useHistory } from 'react-router-dom'
 
-import { RoomType } from '../lib/apiTypes'
+import { RoomType } from 'lib/apiTypes'
 type RoomProps = Pick<RoomType, 'id' | 'name'>
 
 const ROOMS_QUERY = gql`

--- a/src/components/RoomSelector.tsx
+++ b/src/components/RoomSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import gql from 'graphql-tag'
-import { useMutation, useQuery } from '@apollo/react-hooks'
+import { useQuery } from '@apollo/react-hooks'
 import { useHistory } from 'react-router-dom'
 
 import { RoomType } from '../lib/apiTypes'
@@ -19,21 +19,13 @@ type RoomsQuery = {
   rooms: RoomProps[]
 }
 
-const ROOM_ACTIVATE = gql`
-  mutation RoomActivate($roomId: ID!) {
-    roomActivate(input: { roomId: $roomId }) {
-      errors
-    }
-  }
-`
-
 const Room: React.FC<RoomProps & { active: boolean }> = ({ id, name, active }) => {
   const { push } = useHistory()
   const onClick = (): ReturnType<typeof push> => push(`/room/${id}`)
 
   return (
     <li>
-      {name} {active && "(currently active)"}
+      {name} {active && '(currently active)'}
       <button onClick={onClick}>Join</button>
     </li>
   )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import App from './App'
+import App from 'App'
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/src/lib/WebsocketClient/client.ts
+++ b/src/lib/WebsocketClient/client.ts
@@ -1,6 +1,6 @@
 import { channels, DataMessage, Message, Options, Subscriptions } from './types'
 
-import { RoomType } from '../apiTypes'
+import { RoomType } from 'lib/apiTypes'
 
 export const awaitWebsocket = (token: string): Promise<WebSocket> => {
   return new Promise((resolve, reject) => {

--- a/src/lib/WebsocketClient/client.ts
+++ b/src/lib/WebsocketClient/client.ts
@@ -1,15 +1,6 @@
-import {
-  channels,
-  Channel,
-  DataMessage,
-  Message,
-  Options,
-  Subscriptions,
-} from './types'
+import { channels, DataMessage, Message, Options, Subscriptions } from './types'
 
-import {
-  RoomType
-} from '../apiTypes'
+import { RoomType } from '../apiTypes'
 
 export const awaitWebsocket = (token: string): Promise<WebSocket> => {
   return new Promise((resolve, reject) => {
@@ -24,58 +15,53 @@ export const awaitWebsocket = (token: string): Promise<WebSocket> => {
 
 export class Client {
   private debug: boolean
-  private userSubscription: (room: RoomType) => void = () => {}
-  private subscriptions: { [k in Channel]: { [component: string]: any } }
+  private userSubscription: (room: RoomType) => void = () => ({})
   private websocket: WebSocket
 
   constructor(websocket: WebSocket, options: Options) {
     this.debug = options.debug
     this.websocket = websocket
-    this.subscriptions = {
-      QueuesChannel: {},
-      NowPlayingChannel: {},
-      UsersChannel: {}
-    }
   }
 
-  public bind = () => {
+  public bind = (): void => {
     this.websocket.onerror = this.error
     this.websocket.onmessage = (event: MessageEvent) => {
       this.parse(event)
     }
   }
 
-  public subscribeToUsers = (callback: (room: RoomType) => void): () => void => {
+  public subscribeToUsers = (callback: (room: RoomType) => void): (() => void) => {
     this.send(this.generateSubscription(channels.USERS_CHANNEL, {}))
     this.userSubscription = callback
-    return () => this.send(this.generateUnsubscribe(channels.USERS_CHANNEL))
+    return () => this.send(this.generateUnsubscription(channels.USERS_CHANNEL))
   }
 
-  private error: (event: Event) => void = (event) => {
+  private error: (event: Event) => void = event => {
     this.log(event)
   }
 
   private generateSubscription: <T extends keyof Subscriptions>(
-    channel: T, args: Subscriptions[T]
-  ) => { command: 'subscribe', identifier: string } = (channel, args) => ({
+    channel: T,
+    args: Subscriptions[T],
+  ) => { command: 'subscribe'; identifier: string } = (channel, args) => ({
     command: 'subscribe',
-    identifier: JSON.stringify({ channel, ...args })
+    identifier: JSON.stringify({ channel, ...args }),
   })
 
-  private generateUnsubscribe: <T extends keyof Subscriptions>(
-    channel: T
-  ) => { command: 'unsubscribe', identifier: string } = (channel) => ({
+  private generateUnsubscription: <T extends keyof Subscriptions>(
+    channel: T,
+  ) => { command: 'unsubscribe'; identifier: string } = channel => ({
     command: 'unsubscribe',
-    identifier: JSON.stringify({ channel })
+    identifier: JSON.stringify({ channel }),
   })
 
-  private log: (...args: any[]) => void = (...args) => {
+  private log: (...args: Parameters<typeof console.log>) => void = (...args) => {
     if (this.debug) {
       console.log(...args)
     }
   }
 
-  private notify: (websocketMessage: DataMessage) => void = (websocketMessage) => {
+  private notify: (websocketMessage: DataMessage) => void = websocketMessage => {
     this.log(websocketMessage)
 
     switch (websocketMessage.messageType) {
@@ -86,29 +72,27 @@ export class Client {
     }
   }
 
-  private parse: (event: MessageEvent) => void = (event) => {
+  private parse: (event: MessageEvent) => void = event => {
     const data = JSON.parse(event.data)
     if (data.identifier) {
       data.identifier = JSON.parse(data.identifier)
     }
-    console.log(data)
+
     const parsedData: Message = data
+    this.log(parsedData.type, parsedData)
+
     switch (parsedData.type) {
       case 'ping':
-        this.log(parsedData.type, parsedData)
         return
       case 'confirm_subscription':
-        this.log(parsedData.type, parsedData)
         return
       case 'reject_subscription':
-        this.log(parsedData.type, parsedData)
         return
       case undefined:
-        this.log('notify', parsedData)
         this.notify({ messageType: parsedData.identifier.channel, ...parsedData })
         return
     }
   }
 
-  private send: any = (msg: any) => this.websocket.send(JSON.stringify(msg))
+  private send = (msg: object): void => this.websocket.send(JSON.stringify(msg))
 }

--- a/src/lib/WebsocketClient/types.ts
+++ b/src/lib/WebsocketClient/types.ts
@@ -5,10 +5,7 @@ export const QUEUES_CHANNEL = 'QueuesChannel'
 export const NOW_PLAYING_CHANNEL = 'NowPlayingChannel'
 export const USERS_CHANNEL = 'UsersChannel'
 
-export type Channel =
-  | typeof QUEUES_CHANNEL
-  | typeof NOW_PLAYING_CHANNEL
-  | typeof USERS_CHANNEL
+export type Channel = typeof QUEUES_CHANNEL | typeof NOW_PLAYING_CHANNEL | typeof USERS_CHANNEL
 
 export type Channels = {
   QUEUES_CHANNEL: typeof QUEUES_CHANNEL
@@ -39,10 +36,7 @@ type RejectSubscription = {
   type: 'reject_subscription'
 }
 
-type SystemMessage =
-  | Ping
-  | ConfirmSubscription
-  | RejectSubscription
+type SystemMessage = Ping | ConfirmSubscription | RejectSubscription
 
 type WebsocketMessage<T, K> = {
   messageType: T
@@ -55,12 +49,9 @@ type WebsocketMessage<T, K> = {
   type: undefined
 }
 
-export type DataMessage =
-  | WebsocketMessage<typeof USERS_CHANNEL, { room: RoomType }>
+export type DataMessage = WebsocketMessage<typeof USERS_CHANNEL, { room: RoomType }>
 
-export type Message =
-  | SystemMessage
-  | DataMessage
+export type Message = SystemMessage | DataMessage
 
 // Data
 export type Subscriptions = {

--- a/src/lib/WebsocketClient/types.ts
+++ b/src/lib/WebsocketClient/types.ts
@@ -1,4 +1,4 @@
-import { RoomType } from '../apiTypes'
+import { RoomType } from 'lib/apiTypes'
 
 // Channels
 export const QUEUES_CHANNEL = 'QueuesChannel'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,8 +40,12 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
+    "paths": {
+      "~/*": [
+        "*"
+      ] // resolve any `~/foo/bar` to `<baseUrl>/foo/bar`
+    },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
     publicPath: '/',
   },
   resolve: {
+    modules: ['src', 'node_modules'],
     extensions: ['.ts', '.tsx', '.js', '.json']
   },
   module: {


### PR DESCRIPTION
Runs the linter on some things that I was lazy about.  Allows relative-from-root imports and fixes relative imports, `import { foo } from 'lib/foo'` instead of `import { foo } from '../../lib/foo'`.

Adds a readme!