### PR TITLE
Add netlify config with spa redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
@go-between/folks 

Netlify supports some `toml` file where we can add a redirect to send everything back to `index.html`, which is a thing we need to do to support direct linking to, like `/login` or `/room/whatever`.