### PR TITLE
Why dont you just go ahead and play

### DIFF
--- a/src/Player/Player.tsx
+++ b/src/Player/Player.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useState, useEffect } from 'react'
-import moment from 'moment'
-import ReactPlayer from 'react-player'
 
 import { WebsocketContext } from 'App'
+
+import PlayerPrimitive from './PlayerPrimitive'
 
 type Record = {
   playedAt: string
@@ -15,8 +15,8 @@ type Props = {
   currentRecord?: Record
 }
 const Player: React.FC<Props> = ({ currentRecord }) => {
-  const [player, setPlayer] = useState<ReactPlayer>()
   const [record, setRecord] = useState<Record>()
+  const [volume, setVolume] = useState(1)
 
   useEffect(() => {
     setRecord(currentRecord)
@@ -33,31 +33,19 @@ const Player: React.FC<Props> = ({ currentRecord }) => {
     })
   }, [websocket])
 
-  useEffect(() => {
-    if (!record || !player) {
-      return
-    }
-    const now = moment()
-    const offset = moment.duration(now.diff(record.playedAt))
-
-    player.seekTo(offset.as('seconds'))
-  }, [player, record])
-
   if (!record) {
     return <p>Nothing Playing!</p>
   }
 
-  const setRefFromPlayer = (player: ReactPlayer): void => setPlayer(player)
+  const changeVolume = (ev: React.ChangeEvent<HTMLInputElement>): void => {
+    setVolume(parseFloat(ev.currentTarget.value))
+  }
+
   return (
-    <ReactPlayer
-      ref={setRefFromPlayer}
-      url={`https://www.youtube.com/watch?v=${record.song.youtubeId}`}
-      controls={true}
-      playing={true}
-      volume={0}
-      height="100%"
-      width="100%"
-    />
+    <>
+      <PlayerPrimitive playedAt={record.playedAt} youtubeId={record.song.youtubeId} volume={volume} />
+      <input onChange={changeVolume} type="range" min="0" max="1" step=".01" />
+    </>
   )
 }
 

--- a/src/Player/Player.tsx
+++ b/src/Player/Player.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState, useEffect } from 'react'
+import { Box } from 'rebass'
 
 import { WebsocketContext } from 'App'
 
@@ -17,6 +18,7 @@ type Props = {
 const Player: React.FC<Props> = ({ currentRecord }) => {
   const [record, setRecord] = useState<Record>()
   const [volume, setVolume] = useState(1)
+  const [progress, setProgress] = useState(0)
 
   useEffect(() => {
     setRecord(currentRecord)
@@ -37,13 +39,24 @@ const Player: React.FC<Props> = ({ currentRecord }) => {
     return <p>Nothing Playing!</p>
   }
 
+  const changeProgress = (opts: { played: number }): void => {
+    setProgress(opts.played * 100)
+  }
   const changeVolume = (ev: React.ChangeEvent<HTMLInputElement>): void => {
     setVolume(parseFloat(ev.currentTarget.value))
   }
 
   return (
     <>
-      <PlayerPrimitive playedAt={record.playedAt} youtubeId={record.song.youtubeId} volume={volume} />
+      <PlayerPrimitive
+        changeProgress={changeProgress}
+        playedAt={record.playedAt}
+        youtubeId={record.song.youtubeId}
+        volume={volume}
+      />
+      <Box width="100%" height="6px">
+        <Box width={`${progress}%`} height="100%" bg="text" />
+      </Box>
       <input onChange={changeVolume} type="range" min="0" max="1" step=".01" />
     </>
   )

--- a/src/Player/Player.tsx
+++ b/src/Player/Player.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useEffect } from 'react'
 import { Box } from 'rebass'
+import { Label, Slider } from '@rebass/forms'
 
 import { WebsocketContext } from 'App'
 
@@ -17,7 +18,7 @@ type Props = {
 }
 const Player: React.FC<Props> = ({ currentRecord }) => {
   const [record, setRecord] = useState<Record>()
-  const [volume, setVolume] = useState(1)
+  const [volume, setVolume] = useState(100)
   const [progress, setProgress] = useState(0)
 
   useEffect(() => {
@@ -43,7 +44,7 @@ const Player: React.FC<Props> = ({ currentRecord }) => {
     setProgress(opts.played * 100)
   }
   const changeVolume = (ev: React.ChangeEvent<HTMLInputElement>): void => {
-    setVolume(parseFloat(ev.currentTarget.value))
+    setVolume(parseInt(ev.currentTarget.value, 10))
   }
 
   return (
@@ -57,7 +58,8 @@ const Player: React.FC<Props> = ({ currentRecord }) => {
       <Box width="100%" height="6px">
         <Box width={`${progress}%`} height="100%" bg="text" />
       </Box>
-      <input onChange={changeVolume} type="range" min="0" max="1" step=".01" />
+      <Label>Volume</Label>
+      <Slider onChange={changeVolume} value={volume} />
     </>
   )
 }

--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react'
+import ReactPlayer from 'react-player'
+import moment from 'moment'
+
+type Props = {
+  playedAt: string
+  youtubeId: string
+  volume: number
+}
+
+const PlayerPrimitive: React.FC<Props> = ({ playedAt, youtubeId, volume }) => {
+  const [player, setPlayer] = useState<ReactPlayer>()
+  const setRefFromPlayer = (player: ReactPlayer): void => setPlayer(player)
+
+  useEffect(() => {
+    if (!player) {
+      return
+    }
+    const start = Math.floor(moment.duration(moment().diff(playedAt)).as('seconds'))
+    if (start <= 1) {
+      return
+    }
+
+    player.seekTo(start, 'seconds')
+  }, [player, playedAt])
+
+  return (
+    <ReactPlayer
+      ref={setRefFromPlayer}
+      url={`https://www.youtube.com/watch?v=${youtubeId}&nonce=${playedAt}`}
+      playing={true}
+      volume={volume}
+      height="100%"
+      width="100%"
+    />
+  )
+}
+
+export default PlayerPrimitive

--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -3,12 +3,13 @@ import ReactPlayer from 'react-player'
 import moment from 'moment'
 
 type Props = {
+  changeProgress: (opts: { played: number }) => void
   playedAt: string
   youtubeId: string
   volume: number
 }
 
-const PlayerPrimitive: React.FC<Props> = ({ playedAt, youtubeId, volume }) => {
+const PlayerPrimitive: React.FC<Props> = ({ changeProgress, playedAt, youtubeId, volume }) => {
   const [player, setPlayer] = useState<ReactPlayer>()
   const setRefFromPlayer = (player: ReactPlayer): void => setPlayer(player)
 
@@ -33,6 +34,7 @@ const PlayerPrimitive: React.FC<Props> = ({ playedAt, youtubeId, volume }) => {
       height="100%"
       width="100%"
       style={{ pointerEvents: 'none' }}
+      onProgress={changeProgress}
     />
   )
 }

--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -32,6 +32,7 @@ const PlayerPrimitive: React.FC<Props> = ({ playedAt, youtubeId, volume }) => {
       volume={volume}
       height="100%"
       width="100%"
+      style={{ pointerEvents: 'none' }}
     />
   )
 }

--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -30,7 +30,7 @@ const PlayerPrimitive: React.FC<Props> = ({ changeProgress, playedAt, youtubeId,
       ref={setRefFromPlayer}
       url={`https://www.youtube.com/watch?v=${youtubeId}&nonce=${playedAt}`}
       playing={true}
-      volume={volume}
+      volume={volume / 100.0}
       height="100%"
       width="100%"
       style={{ pointerEvents: 'none' }}

--- a/src/lib/WebsocketClient/client.ts
+++ b/src/lib/WebsocketClient/client.ts
@@ -97,8 +97,6 @@ export class Client {
   }
 
   private notify: (websocketMessage: DataMessage) => void = websocketMessage => {
-    this.log(websocketMessage)
-
     switch (websocketMessage.messageType) {
       case channels.MESSAGE_CHANNEL:
         const message = websocketMessage.message.data.message
@@ -126,17 +124,21 @@ export class Client {
     }
 
     const parsedData: Message = data
-    this.log(parsedData.type, parsedData)
-
     switch (parsedData.type) {
       case 'ping':
         return
       case 'confirm_subscription':
+        this.log(parsedData.type, parsedData)
         return
       case 'reject_subscription':
+        this.log(parsedData.type, parsedData)
         return
       case undefined:
+        this.log(parsedData.identifier.channel, parsedData)
         this.notify({ messageType: parsedData.identifier.channel, ...parsedData })
+        return
+      default:
+        this.log('unknown message', parsedData)
         return
     }
   }

--- a/src/rebass__forms.extension.d.ts
+++ b/src/rebass__forms.extension.d.ts
@@ -1,0 +1,8 @@
+// Slider does not yet exist, so we sort of fake it here.
+// See:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42409
+import '@rebass/forms'
+
+declare module '@rebass/forms' {
+  // eslint-disable-next-line
+  export const Slider: any
+}


### PR DESCRIPTION
@go-between/folks 

Extracts the `ReactPlayer` and surrounding code into a `PlayerPrimitive` component.  Adds a volume slider and a progress bar, disables controls and click-to-pause on youtube videos.

Solves at least the "start halfway through" bug (by default if you call `seekTo` with a decimal, it will treat it as a percent of the video that you want to seek to, so when a song starts and we find that the diff is like 0.68 seconds, it'd jump to 68% of the way through).

Maybe also solved the "song doesn't start"?  We'll have to see.

<img width="867" alt="Screen Shot 2020-02-16 at 12 04 53 PM" src="https://user-images.githubusercontent.com/59452077/74610157-4c253c00-50b6-11ea-8819-b9999e74b738.png">
