### PR TITLE
Ensure new chat messages scroll to bottom

### DIFF
--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useQuery } from '@apollo/react-hooks'
 import { Box, Heading, Flex } from 'rebass'
-import { Loader } from 'react-feather'
+import { Home as UserHome, Loader, Users } from 'react-feather'
 
 import { USER_QUERY, UserQuery } from './graphql'
 import RoomSelector from './RoomSelector'
@@ -36,6 +36,7 @@ const Home: React.FC = () => {
     <Container>
       <Box mt={4}>
         <Heading as="h2" mb={3} fontSize={[4, 6]}>
+          <Users />
           Your Teams
         </Heading>
       </Box>
@@ -43,6 +44,7 @@ const Home: React.FC = () => {
       <TeamSelector teams={data.user.teams} activeTeam={data.user.activeTeam?.id} />
 
       <Heading as="h2" mb={3} fontSize={[4, 6]}>
+        <UserHome />
         Available Rooms
         {/* <i>{data.user.activeTeam?.name}</i> */}
       </Heading>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -67,9 +67,6 @@ const Login: React.FC = () => {
       </Box>
       <Box
         sx={{
-          // borderWidth: '1px',
-          // borderStyle: 'solid',
-          // borderColor: 'gray200',
           borderRadius: 4,
           boxShadow: 'xl',
           maxWidth: 400,
@@ -95,7 +92,7 @@ const Login: React.FC = () => {
               }}
             >
               <Mail color="#4A5568" size={20} />
-              <Input type="text" value={email} onChange={setFromEvent(setEmail)} />
+              <Input type="text" value={email} onChange={setFromEvent(setEmail)} placeholder="e.g. jamcity@musicbox.fm" />
             </Box>
           </Box>
 

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -92,7 +92,12 @@ const Login: React.FC = () => {
               }}
             >
               <Mail color="#4A5568" size={20} />
-              <Input type="text" value={email} onChange={setFromEvent(setEmail)} placeholder="e.g. jamcity@musicbox.fm" />
+              <Input
+                type="text"
+                value={email}
+                onChange={setFromEvent(setEmail)}
+                placeholder="e.g. jamcity@musicbox.fm"
+              />
             </Box>
           </Box>
 

--- a/src/Player/Player.tsx
+++ b/src/Player/Player.tsx
@@ -54,7 +54,6 @@ const Player: React.FC<Props> = ({ currentRecord }) => {
       url={`https://www.youtube.com/watch?v=${record.song.youtubeId}`}
       controls={true}
       playing={true}
-      volume={0}
       height="100%"
       width="100%"
     />

--- a/src/Room/MessageEntry.tsx
+++ b/src/Room/MessageEntry.tsx
@@ -36,7 +36,7 @@ const MessageEntry: React.FC = () => {
     >
       <Label>Type Away and Hit Enter</Label>
       <Box>
-        <Input type="text" onChange={onChange} onKeyPress={onKeyPress} value={message} />
+        <Input type="text" onChange={onChange} placeholder="Message the room" onKeyPress={onKeyPress} value={message} />
       </Box>
     </Box>
   )

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -34,7 +34,7 @@ const Messages: React.FC = () => {
       if (chat) {
         chat.scrollTop = chat.scrollHeight
       }
-    }, 100);
+    }, 100)
   }, [messages, newMessage])
 
   const websocket = useContext(WebsocketContext)
@@ -65,7 +65,7 @@ const Messages: React.FC = () => {
         <Flex alignItems="top">
           <Box
             sx={{
-              minWidth: 'auto'
+              minWidth: 'auto',
             }}
           >
             <Box

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -28,6 +28,13 @@ const Messages: React.FC = () => {
     const newMessages = [...messages, newMessage].sort((prev, next) => (prev.createdAt > next.createdAt ? 1 : 0))
     setMessages(newMessages)
     setNewMessage(null)
+    // TODO: revist this and see if there's a more elegant way to do this without using setTimeout
+    const chat = document.getElementById('chat')
+    setTimeout(() => {
+      if (chat) {
+        chat.scrollTop = chat.scrollHeight
+      }
+    }, 100);
   }, [messages, newMessage])
 
   const websocket = useContext(WebsocketContext)
@@ -56,7 +63,11 @@ const Messages: React.FC = () => {
         }}
       >
         <Flex alignItems="top">
-          <Box>
+          <Box
+            sx={{
+              minWidth: 'auto'
+            }}
+          >
             <Box
               sx={{
                 alignItems: 'center',
@@ -95,6 +106,7 @@ const Messages: React.FC = () => {
 
   return (
     <Box
+      id="chat"
       sx={{
         overflowY: 'scroll',
       }}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,24 +5,14 @@ const Footer: React.FC = () => (
   <Flex
     as="footer"
     sx={{
-      bg: 'accent'
+      bg: 'accent',
     }}
   >
-    <Box>
-      No Song Playing /
-      Song details
-    </Box>
+    <Box>No Song Playing / Song details</Box>
 
-    <Box>
-      Controls /
-      play /
-      thumbs up or down
-    </Box>
+    <Box>Controls / play / thumbs up or down</Box>
 
-    <Box>
-      Volume /
-      Mute
-    </Box>
+    <Box>Volume / Mute</Box>
   </Flex>
 )
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Box, Flex } from 'rebass'
+
+const Footer: React.FC = () => (
+  <Flex
+    as="footer"
+    sx={{
+      bg: 'accent'
+    }}
+  >
+    <Box>
+      No Song Playing /
+      Song details
+    </Box>
+
+    <Box>
+      Controls /
+      play /
+      thumbs up or down
+    </Box>
+
+    <Box>
+      Volume /
+      Mute
+    </Box>
+  </Flex>
+)
+
+export default Footer

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,3 +1,5 @@
+import { fontSize } from "styled-system"
+
 const colors = {
   accent: '#2D3748', // a contrast color for emphasizing UI
   background: '#1A202C', // body background color
@@ -113,12 +115,15 @@ export default {
       bg: 'background',
       borderRadius: 4,
       borderColor: 'transparent',
-      boxShadow: 'base',
       color: 'text',
       p: 2,
       '&:focus': {
         outline: 'none',
       },
+      '&::placeholder': {
+        color: '#E2E8F0',
+        fontSize: 2,
+      }
     },
     heading: {
       color: 'text',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,5 +1,3 @@
-import { fontSize } from "styled-system"
-
 const colors = {
   accent: '#2D3748', // a contrast color for emphasizing UI
   background: '#1A202C', // body background color
@@ -123,7 +121,7 @@ export default {
       '&::placeholder': {
         color: '#E2E8F0',
         fontSize: 2,
-      }
+      },
     },
     heading: {
       color: 'text',


### PR DESCRIPTION
@go-between/folks 

- uses setTimeout hack to make sure new chat messages scroll to the most recent. This happens because there is a small async delay while react renders the message list while we're trying to reset the scrollTop position.
- WIP design stuffs

Basecamp Todo: https://3.basecamp.com/4361952/buckets/14871813/todos/2412439281/edit?replace=true