### PR TITLE
Unique name colors

### DIFF
--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -8,9 +8,9 @@ import { WebsocketContext } from 'App'
 import { MESSAGES_QUERY, MessagesQuery, Message } from './graphql'
 
 const FFFFFF_IN_DEC = 16777215
-const getUserColor = (name: string) => {
+const getUserColor = (name: string): string => {
   let nums = ''
-  for(var i=0; i < name.length; i++) {
+  for (let i = 0; i < name.length; i++) {
     nums += name.charCodeAt(i)
   }
   return `#${(parseInt(nums, 10) % FFFFFF_IN_DEC).toString(16)}`
@@ -99,7 +99,9 @@ const Messages: React.FC = () => {
                 pb: 1,
               }}
             >
-              <Box as="span" color={getUserColor(message.user.name)} >{message.user.name}</Box>
+              <Box as="span" color={getUserColor(message.user.name)}>
+                {message.user.name}
+              </Box>
               {withSong}
               <Box as="span" color="#CBD5E0" fontSize={1} px={2}>
                 {displayDate}

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -7,6 +7,20 @@ import { WebsocketContext } from 'App'
 
 import { MESSAGES_QUERY, MessagesQuery, Message } from './graphql'
 
+const zeroPad = (n, w) => {
+  while(n.toString().length<w) n = '0' + n;
+  return n;
+}
+
+const FFFFFF_IN_DEC = 16777215
+const getUserColor = name => {
+  let nums = ''
+  for(var i=0; i<name.length; i++) {
+    nums += zeroPad(name.charCodeAt(i), 3);
+  }
+  return `#${(nums % FFFFFF_IN_DEC).toString(16)}`
+}
+
 const Messages: React.FC = () => {
   const { data, loading } = useQuery<MessagesQuery['data'], MessagesQuery['vars']>(MESSAGES_QUERY)
   const [messages, setMessages] = useState<Message[]>([])
@@ -90,7 +104,7 @@ const Messages: React.FC = () => {
                 pb: 1,
               }}
             >
-              {message.user.name}
+              <Box as="span" color={getUserColor(message.user.name)} >{message.user.name}</Box>
               {withSong}
               <Box as="span" color="#CBD5E0" fontSize={1} px={2}>
                 {displayDate}

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -53,7 +53,7 @@ const Messages: React.FC = () => {
   }
 
   const messageLines = messages.map(message => {
-    const withSong = message.roomPlaylistRecord && <i>during {message.roomPlaylistRecord.song.name}</i>
+    const withSong = message.roomPlaylistRecord && <i> during {message.roomPlaylistRecord.song.name}</i>
     const displayDate = moment(message.createdAt).format('ddd h:mm a')
     return (
       <Box

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -7,18 +7,13 @@ import { WebsocketContext } from 'App'
 
 import { MESSAGES_QUERY, MessagesQuery, Message } from './graphql'
 
-const zeroPad = (n, w) => {
-  while(n.toString().length<w) n = '0' + n;
-  return n;
-}
-
 const FFFFFF_IN_DEC = 16777215
-const getUserColor = name => {
+const getUserColor = (name: string) => {
   let nums = ''
-  for(var i=0; i<name.length; i++) {
-    nums += zeroPad(name.charCodeAt(i), 3);
+  for(var i=0; i < name.length; i++) {
+    nums += name.charCodeAt(i)
   }
-  return `#${(nums % FFFFFF_IN_DEC).toString(16)}`
+  return `#${(parseInt(nums, 10) % FFFFFF_IN_DEC).toString(16)}`
 }
 
 const Messages: React.FC = () => {


### PR DESCRIPTION
Reading names is difficult when there's no way to differentiate between them in chat.

This adds a color encoding scheme so each user's color will show up unique based on the user name.

Not perfect, but a start.
![image](https://user-images.githubusercontent.com/408994/74985269-1c9f6800-5405-11ea-8b1d-969c4cd57ea5.png)
