### PR TITLE
Websocketeer

### DIFF
--- a/src/Player/Player.tsx
+++ b/src/Player/Player.tsx
@@ -33,10 +33,6 @@ const Player: React.FC<Props> = ({ currentRecord }) => {
   const websocket = useContext(WebsocketContext)
   const { deleteRecord } = useContext(PlaylistRecordContext)
   useEffect(() => {
-    if (!websocket) {
-      return
-    }
-
     return websocket.subscribeToNowPlaying(nowPlaying => {
       setRecord(nowPlaying.currentRecord)
       if (!!nowPlaying.currentRecord) {

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -47,10 +47,6 @@ const Messages: React.FC = () => {
 
   const websocket = useContext(WebsocketContext)
   useEffect(() => {
-    if (!websocket) {
-      return
-    }
-
     return websocket.subscribeToMessage(message => {
       setNewMessage(message)
     })

--- a/src/Room/Room.tsx
+++ b/src/Room/Room.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react'
+import React, { useContext, useEffect } from 'react'
 import { useMutation } from '@apollo/react-hooks'
 import { useParams } from 'react-router-dom'
 import { Flex } from 'rebass'
 
 import { SideNav } from 'components'
+import { WebsocketContext } from 'App'
 
 import Chat from './Chat'
 import Main from './Main'
@@ -13,7 +14,10 @@ import PlaylistRecordContextProvider from './PlaylistRecordContextProvider'
 const Room: React.FC = () => {
   const { id } = useParams()
 
-  const [roomActivate, { data, loading }] = useMutation<RoomActivate['data'], RoomActivate['vars']>(ROOM_ACTIVATE)
+  const websocket = useContext(WebsocketContext)
+  const [roomActivate, { data, loading }] = useMutation<RoomActivate['data'], RoomActivate['vars']>(ROOM_ACTIVATE, {
+    onCompleted: websocket.subscribeForRoom,
+  })
 
   useEffect(() => {
     if (!id) {
@@ -21,7 +25,8 @@ const Room: React.FC = () => {
     }
 
     roomActivate({ variables: { roomId: id } })
-  }, [id, roomActivate])
+    return websocket.unsubscribeForRoom
+  }, [id, roomActivate, websocket.unsubscribeForRoom])
 
   if (!data || loading) {
     return <p>Loading</p>

--- a/src/Room/Users.tsx
+++ b/src/Room/Users.tsx
@@ -13,10 +13,6 @@ const Users: React.FC<Props> = ({ initialUsers }) => {
   const websocket = useContext(WebsocketContext)
 
   useEffect(() => {
-    if (!websocket) {
-      return
-    }
-
     return websocket.subscribeToUsers(room => {
       setUsers(room.users)
     })

--- a/src/RoomPlaylist/RoomPlaylist.tsx
+++ b/src/RoomPlaylist/RoomPlaylist.tsx
@@ -26,10 +26,6 @@ const RoomPlaylist: React.FC<Props> = ({ roomId }) => {
   const websocket = useContext(WebsocketContext)
 
   useEffect(() => {
-    if (!websocket) {
-      return
-    }
-
     return websocket.subscribeToRoomPlaylist(roomPlaylist => {
       setPlaylistRecords(roomPlaylist)
     })

--- a/src/lib/WebsocketClient/client.ts
+++ b/src/lib/WebsocketClient/client.ts
@@ -28,16 +28,16 @@ export class Client {
   private websocket: WebSocket | null = null
 
   private messageMessages: Array<MessageChannelMessage['message']> = []
-  private messageSubscription?: (message: MessageChannelMessage['message']) => void
+  private messageSubscription: ((message: MessageChannelMessage['message']) => void) | null = null
 
   private nowPlayingMessages: Array<NowPlayingChannelMessage['room']> = []
-  private nowPlayingSubscription?: (currentRecord: NowPlayingChannelMessage['room']) => void
+  private nowPlayingSubscription: ((currentRecord: NowPlayingChannelMessage['room']) => void) | null = null
 
   private roomPlaylistMessages: Array<RoomPlaylistMessage['roomPlaylist']> = []
-  private roomPlaylistSubscription?: (roomPlaylist: RoomPlaylistMessage['roomPlaylist']) => void
+  private roomPlaylistSubscription: ((roomPlaylist: RoomPlaylistMessage['roomPlaylist']) => void) | null = null
 
   private userMessages: Array<UserChannelMessage['room']> = []
-  private userSubscription?: (room: UserChannelMessage['room']) => void
+  private userSubscription: ((room: UserChannelMessage['room']) => void) | null = null
 
   constructor(options: Options) {
     this.debug = options.debug
@@ -66,28 +66,36 @@ export class Client {
     this.send(this.generateUnsubscription(channels.USERS_CHANNEL))
   }
 
-  public subscribeToMessage = (callback: (currentRecord: MessageChannelMessage['message']) => void): void => {
+  public subscribeToMessage = (callback: (currentRecord: MessageChannelMessage['message']) => void): (() => void) => {
     this.messageSubscription = callback
     this.messageMessages.forEach(this.messageSubscription)
     this.messageMessages = []
+    return () => (this.messageSubscription = null)
   }
 
-  public subscribeToNowPlaying = (callback: (currentRecord: NowPlayingChannelMessage['room']) => void): void => {
+  public subscribeToNowPlaying = (
+    callback: (currentRecord: NowPlayingChannelMessage['room']) => void,
+  ): (() => void) => {
     this.nowPlayingSubscription = callback
     this.nowPlayingMessages.forEach(this.nowPlayingSubscription)
     this.nowPlayingMessages = []
+    return () => (this.nowPlayingSubscription = null)
   }
 
-  public subscribeToRoomPlaylist = (callback: (roomPlaylist: RoomPlaylistMessage['roomPlaylist']) => void): void => {
+  public subscribeToRoomPlaylist = (
+    callback: (roomPlaylist: RoomPlaylistMessage['roomPlaylist']) => void,
+  ): (() => void) => {
     this.roomPlaylistSubscription = callback
     this.roomPlaylistMessages.forEach(this.roomPlaylistSubscription)
     this.roomPlaylistMessages = []
+    return () => (this.roomPlaylistSubscription = null)
   }
 
-  public subscribeToUsers = (callback: (room: UserChannelMessage['room']) => void): void => {
+  public subscribeToUsers = (callback: (room: UserChannelMessage['room']) => void): (() => void) => {
     this.userSubscription = callback
     this.userMessages.forEach(this.userSubscription)
     this.userMessages = []
+    return () => (this.userSubscription = null)
   }
 
   private error: (event: Event) => void = event => {

--- a/src/lib/WebsocketClient/client.ts
+++ b/src/lib/WebsocketClient/client.ts
@@ -25,50 +25,69 @@ export const awaitWebsocket = (token: string): Promise<WebSocket> => {
 
 export class Client {
   private debug: boolean
-  private messageSubscription: (message: MessageChannelMessage['message']) => void = () => ({})
-  private nowPlayingSubscription: (currentRecord: NowPlayingChannelMessage['room']) => void = () => ({})
-  private roomPlaylistSubscription: (roomPlaylist: RoomPlaylistMessage['roomPlaylist']) => void = () => ({})
-  private userSubscription: (room: UserChannelMessage['room']) => void = () => ({})
-  private websocket: WebSocket
+  private websocket: WebSocket | null = null
 
-  constructor(websocket: WebSocket, options: Options) {
+  private messageMessages: Array<MessageChannelMessage['message']> = []
+  private messageSubscription?: (message: MessageChannelMessage['message']) => void
+
+  private nowPlayingMessages: Array<NowPlayingChannelMessage['room']> = []
+  private nowPlayingSubscription?: (currentRecord: NowPlayingChannelMessage['room']) => void
+
+  private roomPlaylistMessages: Array<RoomPlaylistMessage['roomPlaylist']> = []
+  private roomPlaylistSubscription?: (roomPlaylist: RoomPlaylistMessage['roomPlaylist']) => void
+
+  private userMessages: Array<UserChannelMessage['room']> = []
+  private userSubscription?: (room: UserChannelMessage['room']) => void
+
+  constructor(options: Options) {
     this.debug = options.debug
-    this.websocket = websocket
   }
 
-  public bind = (): void => {
+  public bind = (websocket: WebSocket): void => {
+    this.websocket = websocket
+
     this.websocket.onerror = this.error
     this.websocket.onmessage = (event: MessageEvent) => {
       this.parse(event)
     }
   }
 
-  public subscribeToMessage = (callback: (currentRecord: MessageChannelMessage['message']) => void): (() => void) => {
+  public subscribeForRoom = (): void => {
     this.send(this.generateSubscription(channels.MESSAGE_CHANNEL, {}))
-    this.messageSubscription = callback
-    return () => this.send(this.generateUnsubscription(channels.MESSAGE_CHANNEL))
-  }
-
-  public subscribeToNowPlaying = (
-    callback: (currentRecord: NowPlayingChannelMessage['room']) => void,
-  ): (() => void) => {
     this.send(this.generateSubscription(channels.NOW_PLAYING_CHANNEL, {}))
-    this.nowPlayingSubscription = callback
-    return () => this.send(this.generateUnsubscription(channels.NOW_PLAYING_CHANNEL))
-  }
-
-  public subscribeToRoomPlaylist = (
-    callback: (roomPlaylist: RoomPlaylistMessage['roomPlaylist']) => void,
-  ): (() => void) => {
     this.send(this.generateSubscription(channels.ROOM_PLAYLIST_CHANNEL, {}))
-    this.roomPlaylistSubscription = callback
-    return () => this.send(this.generateUnsubscription(channels.ROOM_PLAYLIST_CHANNEL))
+    this.send(this.generateSubscription(channels.USERS_CHANNEL, {}))
   }
 
-  public subscribeToUsers = (callback: (room: UserChannelMessage['room']) => void): (() => void) => {
-    this.send(this.generateSubscription(channels.USERS_CHANNEL, {}))
+  public unsubscribeForRoom = (): void => {
+    this.send(this.generateUnsubscription(channels.MESSAGE_CHANNEL))
+    this.send(this.generateUnsubscription(channels.NOW_PLAYING_CHANNEL))
+    this.send(this.generateUnsubscription(channels.ROOM_PLAYLIST_CHANNEL))
+    this.send(this.generateUnsubscription(channels.USERS_CHANNEL))
+  }
+
+  public subscribeToMessage = (callback: (currentRecord: MessageChannelMessage['message']) => void): void => {
+    this.messageSubscription = callback
+    this.messageMessages.forEach(this.messageSubscription)
+    this.messageMessages = []
+  }
+
+  public subscribeToNowPlaying = (callback: (currentRecord: NowPlayingChannelMessage['room']) => void): void => {
+    this.nowPlayingSubscription = callback
+    this.nowPlayingMessages.forEach(this.nowPlayingSubscription)
+    this.nowPlayingMessages = []
+  }
+
+  public subscribeToRoomPlaylist = (callback: (roomPlaylist: RoomPlaylistMessage['roomPlaylist']) => void): void => {
+    this.roomPlaylistSubscription = callback
+    this.roomPlaylistMessages.forEach(this.roomPlaylistSubscription)
+    this.roomPlaylistMessages = []
+  }
+
+  public subscribeToUsers = (callback: (room: UserChannelMessage['room']) => void): void => {
     this.userSubscription = callback
-    return () => this.send(this.generateUnsubscription(channels.USERS_CHANNEL))
+    this.userMessages.forEach(this.userSubscription)
+    this.userMessages = []
   }
 
   private error: (event: Event) => void = event => {
@@ -100,19 +119,35 @@ export class Client {
     switch (websocketMessage.messageType) {
       case channels.MESSAGE_CHANNEL:
         const message = websocketMessage.message.data.message
-        this.messageSubscription(message)
+        if (!!this.messageSubscription) {
+          this.messageSubscription(message)
+        } else {
+          this.messageMessages.push(message)
+        }
         return
       case channels.NOW_PLAYING_CHANNEL:
         const currentRecord = websocketMessage.message.data.room
-        this.nowPlayingSubscription(currentRecord)
+        if (!!this.nowPlayingSubscription) {
+          this.nowPlayingSubscription(currentRecord)
+        } else {
+          this.nowPlayingMessages.push(currentRecord)
+        }
         return
       case channels.ROOM_PLAYLIST_CHANNEL:
         const roomPlaylist = websocketMessage.message.data.roomPlaylist
-        this.roomPlaylistSubscription(roomPlaylist)
+        if (!!this.roomPlaylistSubscription) {
+          this.roomPlaylistSubscription(roomPlaylist)
+        } else {
+          this.roomPlaylistMessages.push(roomPlaylist)
+        }
         return
       case channels.USERS_CHANNEL:
         const room = websocketMessage.message.data.room
-        this.userSubscription(room)
+        if (!!this.userSubscription) {
+          this.userSubscription(room)
+        } else {
+          this.userMessages.push(room)
+        }
         return
     }
   }
@@ -143,5 +178,11 @@ export class Client {
     }
   }
 
-  private send = (msg: object): void => this.websocket.send(JSON.stringify(msg))
+  private send = (msg: object): void => {
+    if (!this.websocket) {
+      console.error('Attempting to send before websocket initialized')
+      return
+    }
+    this.websocket.send(JSON.stringify(msg))
+  }
 }


### PR DESCRIPTION
@go-between/folks 

Updates websocket client to subscribe to all room-related channels after activating a room, rather than upon the various child components mounting and calling `subscribeTo` whatever.  We should see the room itself rerender less-often than the child components, so I'm hoping this will address some instability in how the websocket connection is handled.