### PR TITLE
Replace chat message input with textarea

### DIFF
--- a/src/Room/MessageEntry.tsx
+++ b/src/Room/MessageEntry.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useMutation } from '@apollo/react-hooks'
 import { Box } from 'rebass'
-import { Input, Label } from '@rebass/forms'
+import { Input, Label, Textarea } from '@rebass/forms'
 
 import { MESSAGE_CREATE, MessageCreate } from './graphql'
 
@@ -9,7 +9,7 @@ const MessageEntry: React.FC = () => {
   const [message, setMessage] = useState<string>('')
   const [messageCreate] = useMutation<MessageCreate['data'], MessageCreate['vars']>(MESSAGE_CREATE)
 
-  const onChange = (ev: React.ChangeEvent<HTMLInputElement>): void => {
+  const onChange = (ev: React.ChangeEvent<HTMLTextAreaElement>): void => {
     setMessage(ev.target.value)
   }
 
@@ -34,9 +34,20 @@ const MessageEntry: React.FC = () => {
         p: 3,
       }}
     >
-      <Label>Type Away and Hit Enter</Label>
       <Box>
-        <Input type="text" onChange={onChange} placeholder="Message the room" onKeyPress={onKeyPress} value={message} />
+        <Textarea
+          onChange={onChange} placeholder="Share your thoughts with the room and hit enter" onKeyPress={onKeyPress} value={message}
+          sx={{
+            bg: 'background',
+            borderColor: 'transparent',
+            borderRadius: 4,
+            minHeight:'70px',
+            maxHeight: '300px',
+            height: 'auto',
+            resize: 'vertical',
+            overflow: 'auto',
+          }}
+        />
       </Box>
     </Box>
   )

--- a/src/Room/MessageEntry.tsx
+++ b/src/Room/MessageEntry.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useMutation } from '@apollo/react-hooks'
 import { Box } from 'rebass'
-import { Input, Label, Textarea } from '@rebass/forms'
+import { Textarea } from '@rebass/forms'
 
 import { MESSAGE_CREATE, MessageCreate } from './graphql'
 
@@ -36,12 +36,15 @@ const MessageEntry: React.FC = () => {
     >
       <Box>
         <Textarea
-          onChange={onChange} placeholder="Share your thoughts with the room and hit enter" onKeyPress={onKeyPress} value={message}
+          onChange={onChange}
+          placeholder="Share your thoughts with the room and hit enter"
+          onKeyPress={onKeyPress}
+          value={message}
           sx={{
             bg: 'background',
             borderColor: 'transparent',
             borderRadius: 4,
-            minHeight:'70px',
+            minHeight: '70px',
             maxHeight: '300px',
             height: 'auto',
             resize: 'vertical',


### PR DESCRIPTION
@go-between/folks 

My sister's in town, so I'm very distracted tonight, but I wanted to make sure I did at least ONE thing tonight, so I updated the message input to be a textarea that gives the user some more breathing room when typing longer messages.

<img width="595" alt="image" src="https://user-images.githubusercontent.com/1316075/76376684-e4f65280-6316-11ea-913c-b238bb4bd856.png">


<img width="598" alt="image" src="https://user-images.githubusercontent.com/1316075/76376695-eb84ca00-6316-11ea-9ccd-2ec61f11a656.png">
