### PR TITLE
Always refetch data with graphql to avoid weird caching issues

### DIFF
--- a/src/Context/UserContextProvider.tsx
+++ b/src/Context/UserContextProvider.tsx
@@ -49,7 +49,7 @@ const USER_QUERY = gql`
 
 const UserContext = createContext<User | null>(null)
 const UserContextProvider: React.FC = ({ children }) => {
-  const { loading, data } = useQuery<UserQuery['data']>(USER_QUERY)
+  const { loading, data } = useQuery<UserQuery['data']>(USER_QUERY, { fetchPolicy: 'network-only' })
 
   if (!data || loading) {
     return <p>Loading...</p>

--- a/src/Home/RoomSelector.tsx
+++ b/src/Home/RoomSelector.tsx
@@ -38,7 +38,7 @@ type Props = {
   activeRoom?: string
 }
 const RoomSelector: React.FC<Props> = ({ activeRoom }) => {
-  const { loading, error, data } = useQuery<RoomsQuery['data']>(ROOMS_QUERY)
+  const { loading, error, data } = useQuery<RoomsQuery['data']>(ROOMS_QUERY, { fetchPolicy: 'network-only' })
   const [roomName, setRoomName] = useState('')
   const [roomCreateMutation] = useMutation<RoomCreate['data'], RoomCreate['vars']>(ROOM_CREATE, {
     onCompleted: () => setRoomName(''),

--- a/src/Invitation/Invitation.tsx
+++ b/src/Invitation/Invitation.tsx
@@ -24,6 +24,7 @@ const Invitation: React.FC = () => {
 
   const { loading, data } = useQuery<InvitationQuery['data'], InvitationQuery['vars']>(INVITATION_QUERY, {
     variables: { email, token },
+    fetchPolicy: 'network-only',
   })
   const [invitationAcceptMutation, { data: invitationData }] = useMutation<
     InvitationAccept['data'],

--- a/src/Invitations/Invitations.tsx
+++ b/src/Invitations/Invitations.tsx
@@ -33,7 +33,7 @@ const Invitations: React.FC = () => {
   const [email, setEmail] = useState('')
   const [name, setName] = useState('')
 
-  const { loading, data } = useQuery<InvitationsQuery['data']>(INVITATIONS_QUERY)
+  const { loading, data } = useQuery<InvitationsQuery['data']>(INVITATIONS_QUERY, { fetchPolicy: 'network-only' })
 
   const clearInvitation = (): void => {
     setEmail('')

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -14,6 +14,7 @@ const messagesFrom = moment()
 const Messages: React.FC = () => {
   const { data, loading } = useQuery<MessagesQuery['data'], MessagesQuery['vars']>(MESSAGES_QUERY, {
     variables: { from: messagesFrom },
+    fetchPolicy: 'network-only',
   })
   const [messages, setMessages] = useState<MessageType[]>([])
   const [newMessage, setNewMessage] = useState<MessageType | null>(null)

--- a/src/RoomPlaylist/RoomPlaylist.tsx
+++ b/src/RoomPlaylist/RoomPlaylist.tsx
@@ -15,6 +15,7 @@ const RoomPlaylist: React.FC<Props> = ({ roomId }) => {
 
   const { data, loading } = useQuery<RoomPlaylistQuery['data'], RoomPlaylistQuery['vars']>(ROOM_PLAYLIST_QUERY, {
     variables: { roomId },
+    fetchPolicy: 'network-only',
   })
 
   useEffect(() => {

--- a/src/UserPlaylist/UserPlaylist.tsx
+++ b/src/UserPlaylist/UserPlaylist.tsx
@@ -17,7 +17,9 @@ const reorder: Reorder = (list, startIndex, endIndex) => {
   return result
 }
 const UserPlaylist: React.FC = () => {
-  const { data, loading } = useQuery<RoomPlaylistForUserQuery['data']>(ROOM_PLAYLIST_FOR_USER_QUERY)
+  const { data, loading } = useQuery<RoomPlaylistForUserQuery['data']>(ROOM_PLAYLIST_FOR_USER_QUERY, {
+    fetchPolicy: 'network-only',
+  })
   const { deleteRecord, playlistRecords, reorderRecords, setPlaylistRecords } = usePlaylistRecordContext()
 
   useEffect(() => {


### PR DESCRIPTION
@go-between/folks 

Set our fetch policy to always use the network instead of relying on the cache -- ensures we don't run into weird caching bugs when you switch rooms!