### PR TITLE
Song name

### DIFF
--- a/src/QuickAdd/Results.tsx
+++ b/src/QuickAdd/Results.tsx
@@ -36,7 +36,6 @@ type SearchResultProps = {
 const SearchResult: React.FC<SearchResultProps> = ({ alreadyAdded, nowPlaying, result, selectResult, selected }) => {
   const onClick = (ev: React.MouseEvent): void => {
     ev.stopPropagation()
-    console.log('hi')
     selectResult(result)
   }
 

--- a/src/QuickAdd/Results.tsx
+++ b/src/QuickAdd/Results.tsx
@@ -34,7 +34,11 @@ type SearchResultProps = {
 }
 
 const SearchResult: React.FC<SearchResultProps> = ({ alreadyAdded, nowPlaying, result, selectResult, selected }) => {
-  const onClick = (): void => selectResult(result)
+  const onClick = (ev: React.MouseEvent): void => {
+    ev.stopPropagation()
+    console.log('hi')
+    selectResult(result)
+  }
 
   return (
     <Box
@@ -91,10 +95,8 @@ const SearchResult: React.FC<SearchResultProps> = ({ alreadyAdded, nowPlaying, r
 }
 
 const FloatingResults: React.FC = ({ children }) => {
-  const preventEventBubbling = (event: React.MouseEvent): void => event.preventDefault()
   return (
     <Box
-      onClick={preventEventBubbling}
       sx={{
         bg: 'accent',
         borderRadius: 4,
@@ -119,10 +121,7 @@ const Results: React.FC = () => {
   const { currentRecord } = useCurrentRecordContext()
   const resultsRef = createRef<HTMLUListElement>()
   const selectedRef = createRef<HTMLDivElement>()
-  const clear = (): void => {
-    setResults([])
-    setQuery('')
-  }
+
   const resultItems = results.map((result, idx) => {
     const alreadyAdded =
       !!playlistRecords.find(record => record.song.id === result.id) || currentRecord?.song.id === result.id
@@ -155,12 +154,17 @@ const Results: React.FC = () => {
   })
 
   useEffect(() => {
-    if (results.length > 0) {
-      document.addEventListener('click', clear, false)
+    const clear = (): void => {
+      setResults([])
+      setQuery('')
     }
 
-    return () => document.removeEventListener('click', clear, false)
-  }, [results, clear])
+    if (results.length > 0) {
+      window.addEventListener('click', clear, false)
+    }
+
+    return () => window.removeEventListener('click', clear, false)
+  }, [results, setQuery, setResults])
 
   useEffect(() => {
     if (!resultsRef?.current?.parentElement || !selectedRef?.current) {

--- a/src/Room/Message.tsx
+++ b/src/Room/Message.tsx
@@ -62,18 +62,43 @@ const PlayedAt: React.FC<PlayedAtProps> = ({ messageCreated, playedAt, song }) =
   return (
     <Box
       as="span"
-      sx={{ color: 'gray500', cursor: 'pointer', fontSize: 1, fontWeight: '600', textDecoration: 'underline' }}
+      sx={{
+        '&:hover > *': { visibility: 'visible' },
+        position: 'relative',
+        color: 'gray500',
+        cursor: 'pointer',
+        fontSize: 1,
+        fontWeight: '600',
+      }}
     >
       @{' '}
-      {saidAt
-        .minutes()
-        .toString()
-        .padStart(2, '0')}
-      :
-      {saidAt
-        .seconds()
-        .toString()
-        .padStart(2, '0')}
+      <Box as="span" sx={{ textDecoration: 'underline' }}>
+        {saidAt
+          .minutes()
+          .toString()
+          .padStart(2, '0')}
+        :
+        {saidAt
+          .seconds()
+          .toString()
+          .padStart(2, '0')}
+      </Box>
+      <Box
+        sx={{
+          visibility: 'hidden',
+          position: 'absolute',
+          zIndex: 100,
+          width: '200px',
+          bottom: '150%',
+          left: '50%',
+          marginLeft: '-100px',
+          textAlign: 'center',
+          bg: 'accent',
+          p: 2,
+        }}
+      >
+        {song.name}
+      </Box>
     </Box>
   )
 }
@@ -90,6 +115,7 @@ const MessageHeader: React.FC<{ message: MessageType }> = ({ message }) => {
       justifyContent="space-between"
       sx={{
         position: 'relative',
+        overflow: 'visible',
       }}
     >
       <Text
@@ -100,7 +126,7 @@ const MessageHeader: React.FC<{ message: MessageType }> = ({ message }) => {
           display: 'flex',
           fontSize: 2,
           mb: 2,
-          overflow: 'hidden',
+          overflow: 'visible',
           width: '100%',
         }}
       >
@@ -143,14 +169,15 @@ const Message: React.FC<{ message: MessageType }> = ({ message }) => {
           sx={{
             hyphens: 'auto',
             mx: 2,
-            overflowWrap: 'break-word',
-            wordBreak: 'break-word',
-            wordWrap: 'break-word',
             width: '100%',
           }}
         >
           <MessageHeader message={message} />
-          <Text fontSize={2} mb={2} sx={{ whiteSpace: 'pre-line' }}>
+          <Text
+            fontSize={2}
+            mb={2}
+            sx={{ whiteSpace: 'pre-line', overflowWrap: 'break-word', wordBreak: 'break-word', wordWrap: 'break-word' }}
+          >
             {message.message}
           </Text>
         </Box>

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -8,6 +8,52 @@ import { useWebsocketContext } from 'Context'
 import { MESSAGES_QUERY, MessagesQuery, Message as MessageType } from './graphql'
 import Message from './Message'
 
+type MessageGroup = [string, MessageType[]]
+const groupMessagesByRecord = (messages: MessageType[]): MessageGroup[] => {
+  const messageGroups: MessageGroup[] = []
+  let messageGroup: MessageGroup = ['', []]
+  let recordId = ''
+
+  messages.forEach(message => {
+    if ((message.roomPlaylistRecord?.id || '') === recordId) {
+      messageGroup[1].push(message)
+    } else {
+      messageGroups.push(messageGroup)
+      recordId = message.roomPlaylistRecord?.id || ''
+      messageGroup = [recordId, [message]]
+    }
+  })
+  messageGroups.push(messageGroup)
+
+  return messageGroups
+}
+
+const MessageGroup: React.FC<{ messageGroup: MessageGroup }> = ({ messageGroup }) => {
+  const [recordId, messages] = messageGroup
+  const songName = !!recordId && messages[0].song?.name
+
+  return (
+    <>
+      <Box
+        sx={{
+          borderBottomColor: 'text',
+          borderBottomWidth: 1,
+          borderBottomStyle: 'solid',
+          color: 'text',
+          mb: 2,
+          mx: 5,
+          textAlign: 'center',
+        }}
+      >
+        {songName || 'Nothing Playing'}
+      </Box>
+      {messages.map(message => (
+        <Message key={message.id} message={message} />
+      ))}
+    </>
+  )
+}
+
 const messagesFrom = moment()
   .subtract(2, 'days')
   .toISOString()
@@ -57,7 +103,11 @@ const Messages: React.FC = () => {
     return <p>Loading...</p>
   }
 
-  const messageLines = messages.map(message => <Message key={message.id} message={message} />)
+  const groupedMessages = groupMessagesByRecord(messages)
+
+  const messageLines = groupedMessages.map((messageGroup, idx) => (
+    <MessageGroup key={idx} messageGroup={messageGroup} />
+  ))
   return (
     <Box
       ref={chat}

--- a/src/Room/graphql.ts
+++ b/src/Room/graphql.ts
@@ -17,6 +17,9 @@ export const PINNED_MESSAGES_QUERY = gql`
       createdAt
       message
       pinned
+      roomPlaylistRecord {
+        playedAt
+      }
       song {
         name
       }
@@ -45,6 +48,9 @@ export const MESSAGES_QUERY = gql`
       createdAt
       message
       pinned
+      roomPlaylistRecord {
+        playedAt
+      }
       song {
         name
       }
@@ -204,6 +210,9 @@ export type Message = {
   createdAt: string
   message: string
   pinned: boolean
+  roomPlaylistRecord: {
+    playedAt: string
+  } | null
   song: {
     name: string
   } | null

--- a/src/Room/graphql.ts
+++ b/src/Room/graphql.ts
@@ -18,6 +18,7 @@ export const PINNED_MESSAGES_QUERY = gql`
       message
       pinned
       roomPlaylistRecord {
+        id
         playedAt
       }
       song {
@@ -49,6 +50,7 @@ export const MESSAGES_QUERY = gql`
       message
       pinned
       roomPlaylistRecord {
+        id
         playedAt
       }
       song {
@@ -211,6 +213,7 @@ export type Message = {
   message: string
   pinned: boolean
   roomPlaylistRecord: {
+    id: string
     playedAt: string
   } | null
   song: {

--- a/src/lib/WebsocketClient/types.ts
+++ b/src/lib/WebsocketClient/types.ts
@@ -83,6 +83,7 @@ export type MessageChannelMessage = {
     message: string
     pinned: boolean
     roomPlaylistRecord: {
+      id: string
       playedAt: string
     } | null
     song: {

--- a/src/lib/WebsocketClient/types.ts
+++ b/src/lib/WebsocketClient/types.ts
@@ -82,6 +82,9 @@ export type MessageChannelMessage = {
     createdAt: string
     message: string
     pinned: boolean
+    roomPlaylistRecord: {
+      playedAt: string
+    } | null
     song: {
       name: string
     } | null


### PR DESCRIPTION
@go-between/folks 

Cleans up the `Message` component a bit, also adds relative-time to each message and adds song name to tooltip.  Starts grouping messages by the song that was playing.  Also does a bit of clean up around quick-add click-to-close.

![messages](https://user-images.githubusercontent.com/59452077/77239416-69af5f00-6ba8-11ea-9325-260caabb2f40.gif)
