### PR TITLE
add ability to preview songs in My Library and Youtube searches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8320,6 +8320,16 @@
         "has-flag": "^3.0.0"
       }
     },
+    "sweetalert2": {
+      "version": "9.10.2",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-9.10.2.tgz",
+      "integrity": "sha512-muth00S/u8739EY3JqaqAAw3mZd8DNldQWBpIq5GTo9V+2C7qMBEh3oZOr9DmO39va5D2zx4T3xq4VU5VAnLmg=="
+    },
+    "sweetalert2-react-content": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sweetalert2-react-content/-/sweetalert2-react-content-3.0.1.tgz",
+      "integrity": "sha512-VBybIRTIzY2bTkUddcp2wMJ3mp3gfGGX6+BfW2dDrEv6bXM2WtzJpFkM2imFpcPhpkOIf2/J8gLxEu0jBZq0DQ=="
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "react-toast-notifications": "^2.4.0",
     "rebass": "^4.0.7",
     "styled-system": "^5.1.4",
+    "sweetalert2": "^9.10.2",
+    "sweetalert2-react-content": "^3.0.1",
     "use-debounce": "^3.3.0",
     "webpack-merge": "^4.2.2"
   }

--- a/src/Player/Player.tsx
+++ b/src/Player/Player.tsx
@@ -7,10 +7,11 @@ import Gravatar from 'react-gravatar'
 
 import { useWebsocketContext, useUserContext } from 'Context'
 import { useCurrentRecordContext, usePlaylistRecordContext } from 'Room'
-import { persistShowVideo, retrieveShowVideo, persistVolume, retrieveVolume } from 'lib/localStore'
+import { persistShowVideo, retrieveShowVideo, persistVolume } from 'lib/localStore'
 
 import { ROOM_PLAYLIST_RECORD_ABANDON, RoomPlaylistRecordAbandon } from './graphql'
 import PlayerPrimitive from './PlayerPrimitive'
+import { useVolumeContext, PLAYERS } from './VolumeContextProvider'
 
 type Record = {
   playedAt: string
@@ -25,13 +26,14 @@ type Record = {
 }
 
 const Player: React.FC = () => {
-  const [volume, setVolume] = useState(retrieveVolume())
+  // const [volume, setVolume] = useState(retrieveVolume())
   const [showVideo, setShowVideo] = useState(retrieveShowVideo())
   const [progress, setProgress] = useState(0)
 
   const websocket = useWebsocketContext()
   const { deleteRecord } = usePlaylistRecordContext()
   const { currentRecord, setCurrentRecord } = useCurrentRecordContext()
+  const { setUnmutedPlayer, setVolume, unmutedPlayer, volume } = useVolumeContext()
 
   const [roomPlaylistRecordAbandon] = useMutation<RoomPlaylistRecordAbandon['data'], RoomPlaylistRecordAbandon['vars']>(
     ROOM_PLAYLIST_RECORD_ABANDON,
@@ -92,6 +94,7 @@ const Player: React.FC = () => {
     const volume = parseInt(ev.currentTarget.value, 10)
     setVolume(volume)
     persistVolume(volume)
+    setUnmutedPlayer(PLAYERS.main)
   }
 
   const userOwnsCurrentRecord = currentRecord.user.id === user.id
@@ -112,6 +115,11 @@ const Player: React.FC = () => {
   ) : (
     ''
   )
+
+  console.log('umutedPlayer:')
+  console.log(unmutedPlayer)
+  console.log('unmutedPlayer === PLAYERS.main:')
+  console.log(unmutedPlayer === PLAYERS.main)
   return (
     <Box
       width="100%"
@@ -124,7 +132,7 @@ const Player: React.FC = () => {
           changeProgress={changeProgress}
           playedAt={currentRecord.playedAt}
           youtubeId={currentRecord.song.youtubeId}
-          volume={volume}
+          volume={unmutedPlayer === PLAYERS.main ? volume || 0 : 0}
         />
       </Box>
 

--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -3,10 +3,10 @@ import ReactPlayer from 'react-player'
 import moment from 'moment'
 
 type Props = {
-  changeProgress: (opts: { played: number }) => void
+  changeProgress?: (opts: { played: number }) => void
   playedAt: string
-  youtubeId: string
-  volume: number
+  youtubeId: string | undefined
+  volume: number | null
 }
 
 const PlayerPrimitive: React.FC<Props> = ({ changeProgress, playedAt, youtubeId, volume }) => {
@@ -30,7 +30,7 @@ const PlayerPrimitive: React.FC<Props> = ({ changeProgress, playedAt, youtubeId,
       ref={setRefFromPlayer}
       url={`https://www.youtube.com/watch?v=${youtubeId}&nonce=${playedAt}`}
       playing={true}
-      volume={volume / 100.0}
+      volume={(volume || 0) / 100.0}
       height="350px"
       width="100%"
       style={{ border: '1px solid #2D3748', pointerEvents: 'none' }}

--- a/src/Player/VolumeContextProvider.tsx
+++ b/src/Player/VolumeContextProvider.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useState } from 'react'
+
+import { retrieveVolume } from 'lib/localStore'
+
+export const PLAYERS = {
+  main: 'main',
+  preview: 'preview',
+}
+
+type VolumeContext = {
+  unmutedPlayer: string
+  setUnmutedPlayer: (player: string) => void
+  volume: number | null
+  setVolume: (idx: number | null) => void
+}
+
+const VolumeContext = createContext<Partial<VolumeContext>>({})
+const VolumeContextProvider: React.FC = ({ children }) => {
+  const [unmutedPlayer, setUnmutedPlayer] = useState<string>(PLAYERS.main)
+  const [volume, setVolume] = useState<number | null>(retrieveVolume())
+
+  return (
+    <VolumeContext.Provider value={{ setUnmutedPlayer, setVolume, unmutedPlayer, volume }}>
+      {children}
+    </VolumeContext.Provider>
+  )
+}
+
+export const useVolumeContext: () => VolumeContext = () => {
+  const { setUnmutedPlayer, setVolume, unmutedPlayer, volume } = useContext(VolumeContext)
+
+  if (
+    setUnmutedPlayer === undefined ||
+    setVolume === undefined ||
+    unmutedPlayer === undefined ||
+    volume === undefined
+  ) {
+    throw new Error('VolumeContext accessed before being set')
+  }
+
+  return { setUnmutedPlayer, setVolume, unmutedPlayer, volume }
+}
+export default VolumeContextProvider

--- a/src/Player/index.ts
+++ b/src/Player/index.ts
@@ -1,3 +1,5 @@
 import Player from './Player'
 
+export { useVolumeContext } from './VolumeContextProvider'
+
 export default Player

--- a/src/QuickAdd/Results.tsx
+++ b/src/QuickAdd/Results.tsx
@@ -1,12 +1,19 @@
-import React, { createRef, useEffect } from 'react'
+import React, { createRef, useEffect, MouseEvent } from 'react'
 import { Box, Flex, Text } from 'rebass'
-import { Check, Plus } from 'react-feather'
+import { Check, Plus, ZoomIn } from 'react-feather'
+import Swal from 'sweetalert2'
+import withReactContent from 'sweetalert2-react-content'
 
 import { usePlaylistRecordContext } from 'Room/PlaylistRecordContextProvider'
 import { useCurrentRecordContext } from 'Room/CurrentRecordContextProvider'
 
+import PlayerPrimitive from '../Player/PlayerPrimitive'
+import { useVolumeContext, PLAYERS } from '../Player/VolumeContextProvider'
+
 import { Result } from './types'
-import { useResultsContext } from './ResultsContextProvider'
+import { useResultsContext, RESULTS_CONTEXTS } from './ResultsContextProvider'
+
+const ReactSwal = withReactContent(Swal)
 
 const NowPlaying: React.FC = () => {
   return (
@@ -27,16 +34,46 @@ const NowPlaying: React.FC = () => {
 
 type SearchResultProps = {
   alreadyAdded: boolean
+  libraryContext: boolean
   result: Result
   selectResult: (result: Result) => void
   selected: boolean
   nowPlaying: boolean
 }
 
-const SearchResult: React.FC<SearchResultProps> = ({ alreadyAdded, nowPlaying, result, selectResult, selected }) => {
+const SearchResult: React.FC<SearchResultProps> = ({
+  alreadyAdded,
+  libraryContext,
+  nowPlaying,
+  result,
+  selectResult,
+  selected,
+}) => {
+  const { setUnmutedPlayer, volume } = useVolumeContext()
+
   const onClick = (ev: React.MouseEvent): void => {
     ev.stopPropagation()
     selectResult(result)
+  }
+
+  const showPreview = (e: MouseEvent): void => {
+    e.stopPropagation()
+    setUnmutedPlayer(PLAYERS.preview)
+    ReactSwal.fire({
+      allowOutsideClick: () => true,
+      animation: true,
+      cancelButtonText: 'Cancel',
+      confirmButtonText: libraryContext ? 'Add to room' : 'Add to My Library & Room',
+      showCancelButton: true,
+      title: result.name,
+      html: <PlayerPrimitive playedAt="" youtubeId={result.youtubeId} volume={volume} />,
+      width: '30%',
+    }).then(userAction => {
+      if (userAction.value) {
+        selectResult(result)
+      }
+      setUnmutedPlayer(PLAYERS.main)
+    })
   }
 
   return (
@@ -74,12 +111,9 @@ const SearchResult: React.FC<SearchResultProps> = ({ alreadyAdded, nowPlaying, r
           {result.name}
         </Box>
       </Box>
-
       <Box
         sx={{
           alignItems: 'center',
-          bg: 'accent',
-          borderRadius: 4,
           color: 'text',
           cursor: 'pointer',
           display: 'flex',
@@ -87,7 +121,35 @@ const SearchResult: React.FC<SearchResultProps> = ({ alreadyAdded, nowPlaying, r
           mx: 1,
         }}
       >
-        {alreadyAdded ? <Check size={18} /> : <Plus size={18} />}
+        <Box
+          sx={{
+            alignItems: 'center',
+            bg: 'accent',
+            borderRadius: 4,
+            color: 'text',
+            cursor: 'pointer',
+            display: 'flex',
+            p: 1,
+            mx: 1,
+          }}
+          onClick={showPreview}
+        >
+          <ZoomIn size={18} />
+        </Box>
+        <Box
+          sx={{
+            alignItems: 'center',
+            bg: 'accent',
+            borderRadius: 4,
+            color: 'text',
+            cursor: 'pointer',
+            display: 'flex',
+            p: 1,
+            mx: 1,
+          }}
+        >
+          {alreadyAdded ? <Check size={18} /> : <Plus size={18} />}
+        </Box>
       </Box>
     </Box>
   )
@@ -121,6 +183,8 @@ const Results: React.FC = () => {
   const resultsRef = createRef<HTMLUListElement>()
   const selectedRef = createRef<HTMLDivElement>()
 
+  const libraryContext = results[0].resultType === RESULTS_CONTEXTS.library
+
   const resultItems = results.map((result, idx) => {
     const alreadyAdded =
       !!playlistRecords.find(record => record.song.id === result.id) || currentRecord?.song.id === result.id
@@ -132,6 +196,7 @@ const Results: React.FC = () => {
           <SearchResult
             result={result}
             nowPlaying={nowPlaying}
+            libraryContext={libraryContext}
             selectResult={selectResult}
             selected={true}
             alreadyAdded={alreadyAdded}
@@ -144,6 +209,7 @@ const Results: React.FC = () => {
       <SearchResult
         key={result.id}
         nowPlaying={nowPlaying}
+        libraryContext={libraryContext}
         result={result}
         selectResult={selectResult}
         selected={false}

--- a/src/QuickAdd/ResultsContextProvider.tsx
+++ b/src/QuickAdd/ResultsContextProvider.tsx
@@ -7,6 +7,10 @@ import { usePlaylistRecordContext } from 'Room'
 import { Result } from './types'
 import { SongCreateMutation, SONG_CREATE } from './graphql'
 
+export const RESULTS_CONTEXTS = {
+  library: 'library',
+}
+
 type ResultsContext = {
   error: string
   query: string
@@ -32,7 +36,7 @@ const ResultsContextProvider: React.FC = ({ children }) => {
   })
 
   const selectResult = (record: Result): void => {
-    if (record.resultType === 'library') {
+    if (record.resultType === RESULTS_CONTEXTS.library) {
       addRecord(record.id)
     } else {
       createSong({ variables: { youtubeId: record.id } })

--- a/src/QuickAdd/Search.tsx
+++ b/src/QuickAdd/Search.tsx
@@ -53,8 +53,7 @@ export const Search: React.FC = () => {
     onCompleted: data => {
       const libraryResults: Result[] = data.songs.map(song => {
         return {
-          id: song.id,
-          name: song.name,
+          ...song,
           resultType: 'library',
         }
       })
@@ -81,7 +80,7 @@ export const Search: React.FC = () => {
           return
         }
         response.json().then((body: YoutubeResults) => {
-          setResults(deserialize(body))
+          setResults(deserialize(body).map(song => ({ ...song, youtubeId: song.id })))
         })
       })
     }

--- a/src/QuickAdd/graphql.ts
+++ b/src/QuickAdd/graphql.ts
@@ -28,6 +28,7 @@ export const SONGS_QUERY = gql`
     songs(query: $query) {
       id
       name
+      youtubeId
     }
   }
 `

--- a/src/QuickAdd/types.ts
+++ b/src/QuickAdd/types.ts
@@ -2,6 +2,7 @@ export type Result = {
   id: string
   name: string
   resultType: 'youtube' | 'library'
+  youtubeId?: string
 }
 
 export type YoutubeResults = {

--- a/src/QuickAdd/youtube.ts
+++ b/src/QuickAdd/youtube.ts
@@ -6,6 +6,7 @@ export const deserialize = (results: YoutubeResults): Result[] => {
     id: result.id.videoId,
     name: result.snippet.title,
     resultType: 'youtube',
+    youtubeId: result.id.videoId,
   }))
 }
 

--- a/src/Room/Room.tsx
+++ b/src/Room/Room.tsx
@@ -6,6 +6,8 @@ import { Flex } from 'rebass'
 import { SideNav } from 'components'
 import { useWebsocketContext } from 'Context'
 
+import VolumeContextProvider from 'Player/VolumeContextProvider'
+
 import Chat from './Chat'
 import Main from './Main'
 import { ROOM_ACTIVATE, RoomActivate } from './graphql'
@@ -36,20 +38,22 @@ const Room: React.FC = () => {
   return (
     <PlaylistRecordContextProvider>
       <CurrentRecordContextProvider>
-        <Flex
-          sx={{
-            alignItems: 'top',
-            bg: 'background',
-            flexDirection: ['column', 'row'],
-            minHeight: '100vh',
-            mx: 'auto',
-            position: 'relative',
-          }}
-        >
-          <SideNav />
-          <Main room={data.roomActivate.room} />
-          <Chat />
-        </Flex>
+        <VolumeContextProvider>
+          <Flex
+            sx={{
+              alignItems: 'top',
+              bg: 'background',
+              flexDirection: ['column', 'row'],
+              minHeight: '100vh',
+              mx: 'auto',
+              position: 'relative',
+            }}
+          >
+            <SideNav />
+            <Main room={data.roomActivate.room} />
+            <Chat />
+          </Flex>
+        </VolumeContextProvider>
       </CurrentRecordContextProvider>
     </PlaylistRecordContextProvider>
   )


### PR DESCRIPTION
If you could hear the below gif, you would hear the main player muted (if anything is playing) anytime a preview begins.  You would also hear the preview player playing at the same volume that the main player was playing at before the preview started.

![Screen Recording 2020-03-22 at 09 08 PM](https://user-images.githubusercontent.com/408994/77270102-44daea80-6c81-11ea-852a-a9e4a8d315d5.gif)

Improvements:
1. Styling
2. Volume controls on preview player?
3. Better usage of context providers (full discloser, this was my first use of a context provider in React.  I was aware of the tech but just never used it 🤷‍♂ )