### PR TITLE
Chat cleanup

### DIFF
--- a/src/Player/Player.tsx
+++ b/src/Player/Player.tsx
@@ -67,7 +67,6 @@ const Player: React.FC = () => {
           sx={{
             alignItems: 'center',
             justifyContent: 'center',
-            bg: 'accent',
             borderRadius: '100%',
             color: 'text',
             p: 3,

--- a/src/QuickAdd/ResultsContextProvider.tsx
+++ b/src/QuickAdd/ResultsContextProvider.tsx
@@ -38,7 +38,7 @@ const ResultsContextProvider: React.FC = ({ children }) => {
       createSong({ variables: { youtubeId: record.id } })
     }
 
-    addToast(`Successfully added ${record.name}`, { appearance: 'success' })
+    addToast(`Successfully added ${record.name}`, { appearance: 'success', autoDismiss: true, })
   }
 
   return (

--- a/src/QuickAdd/ResultsContextProvider.tsx
+++ b/src/QuickAdd/ResultsContextProvider.tsx
@@ -38,7 +38,7 @@ const ResultsContextProvider: React.FC = ({ children }) => {
       createSong({ variables: { youtubeId: record.id } })
     }
 
-    addToast(`Successfully added ${record.name}`, { appearance: 'success', autoDismiss: true, })
+    addToast(`Successfully added ${record.name}`, { appearance: 'success', autoDismiss: true })
   }
 
   return (

--- a/src/Room/Chat.tsx
+++ b/src/Room/Chat.tsx
@@ -16,7 +16,7 @@ const Chat: React.FC = () => {
         height: '100vh',
         justifyContent: 'space-between',
         overflow: 'scroll',
-        p: 4,
+        py: 4,
         width: ['100%', '40%'],
       }}
     >

--- a/src/Room/Message.tsx
+++ b/src/Room/Message.tsx
@@ -33,7 +33,7 @@ const Pin: React.FC<PinProps> = ({ showPin, previouslyPinned, messageId }) => {
     <Box
       onClick={pinOrUnpin}
       sx={{
-        borderRadius: 6,
+        borderRadius: 4,
         cursor: 'pointer',
         fontSize: 1,
         p: 2,
@@ -42,7 +42,7 @@ const Pin: React.FC<PinProps> = ({ showPin, previouslyPinned, messageId }) => {
         },
       }}
     >
-      {pinned ? <Star size={18} color="#5A67D8" fill="#5A67D8" /> : <Star size={18} />}
+      {pinned ? <Star size={16} color="#5A67D8" fill="#5A67D8" /> : <Star size={16} />}
     </Box>
   )
 }
@@ -61,14 +61,15 @@ const PlayedAt: React.FC<PlayedAtProps> = ({ messageCreated, playedAt, song }) =
 
   return (
     <Box
-      as="span"
       sx={{
-        '&:hover > *': { visibility: 'visible' },
-        position: 'relative',
         color: 'gray500',
         cursor: 'pointer',
         fontSize: 1,
         fontWeight: '600',
+        position: 'relative',
+        '&:hover > *': {
+          visibility: 'visible'
+        },
       }}
     >
       @{' '}
@@ -85,16 +86,21 @@ const PlayedAt: React.FC<PlayedAtProps> = ({ messageCreated, playedAt, song }) =
       </Box>
       <Box
         sx={{
-          visibility: 'hidden',
-          position: 'absolute',
-          zIndex: 100,
-          width: '200px',
+          bg: 'black',
+          borderRadius: 6,
+          border: '1px solid',
+          borderColor: 'gray700',
+          boxShadow: 'xxl',
           bottom: '150%',
+          fontSize: 0,
           left: '50%',
-          marginLeft: '-100px',
-          textAlign: 'center',
-          bg: 'accent',
+          ml: '-100px',
           p: 2,
+          position: 'absolute',
+          textAlign: 'center',
+          visibility: 'hidden',
+          width: '250px',
+          zIndex: 100,
         }}
       >
         {song.name}
@@ -108,81 +114,120 @@ const MessageHeader: React.FC<{ message: MessageType }> = ({ message }) => {
   const playedAt = message.roomPlaylistRecord?.playedAt && moment(message.roomPlaylistRecord?.playedAt)
   const user = useUserContext()
   const showPin = user.id === message.user.id && !!message.song
+  console.log(message.pinned)
 
   return (
-    <Flex
-      alignItems="flex-start"
-      justifyContent="space-between"
-      sx={{
-        position: 'relative',
-        overflow: 'visible',
-      }}
-    >
-      <Text
+    <>
+      <Box
+        className="message-options"
         sx={{
-          alignItems: 'flex-start',
+          alignItems: 'center',
+          border: '1px solid',
+          borderColor: 'accent',
+          bg: 'background',
+          borderRadius: 6,
+          boxShadow: 'xxl',
+          display: 'none',
           justifyContent: 'space-between',
-          flexDirection: 'column',
-          display: 'flex',
-          fontSize: 2,
-          mb: 2,
-          overflow: 'visible',
-          width: '100%',
+          position: 'absolute',
+          top: -3,
+          right: 4,
         }}
       >
-        <Box mb={1}>
-          <Box as="span" sx={{ color: 'text', fontWeight: '800' }}>
+        <Pin messageId={message.id} previouslyPinned={message.pinned} showPin={showPin} />
+      </Box>
+
+      <Flex
+        alignItems="flex-start"
+        justifyContent="space-between"
+        sx={{
+          position: 'relative',
+          overflow: 'visible',
+        }}
+      >
+        <Text
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            fontSize: 2,
+            mb: 1,
+            overflow: 'visible',
+            width: '100%',
+          }}
+        >
+          <Box sx={{ color: 'text', fontWeight: '800' }}>
             {message.user.name}
           </Box>
 
-          <Box as="span" sx={{ color: 'gray500', fontSize: 1, fontWeight: '600', px: 2 }}>
+          <Box sx={{ color: 'gray500', fontSize: 1, fontWeight: '600', px: 2 }}>
             {createdAt.format('ddd h:mm a')}
           </Box>
-
           <PlayedAt messageCreated={createdAt} playedAt={playedAt} song={message.song} />
-        </Box>
-      </Text>
-
-      <Pin messageId={message.id} previouslyPinned={message.pinned} showPin={showPin} />
-    </Flex>
+        </Text>
+      </Flex>
+    </>
   )
 }
 
 const Message: React.FC<{ message: MessageType }> = ({ message }) => {
-  return (
-    <Box
-      key={message.id}
-      sx={{
-        pb: 3,
-      }}
-    >
-      <Flex alignItems="flex-start">
-        <Box
-          sx={{
-            minWidth: 'auto',
-          }}
-        >
-          <Gravatar email={message.user.email} size={32} style={{ borderRadius: '100%' }} />
-        </Box>
-
-        <Box
-          sx={{
-            hyphens: 'auto',
-            mx: 2,
-            width: '100%',
-          }}
-        >
-          <MessageHeader message={message} />
-          <Text
-            fontSize={2}
-            mb={2}
-            sx={{ whiteSpace: 'pre-line', overflowWrap: 'break-word', wordBreak: 'break-word', wordWrap: 'break-word' }}
-          >
-            {message.message}
-          </Text>
-        </Box>
+  const pinnedMessage = () => {
+    return (
+      <Flex
+        sx={{
+          alignItems: 'center',
+          m: 2,
+        }}
+      >
+        <Star size={14} color="#5A67D8" fill="#5A67D8" />
+        <Text fontSize={1} mx={1}>Pinned!</Text>
       </Flex>
-    </Box>
+    )
+  }
+  return (
+    <>
+      <Box
+        key={message.id}
+        sx={{
+          bg: message.pinned ? 'highlight' : 'inherit',
+          position: 'relative',
+          px: 4,
+          py: 3,
+          '&:hover': {
+            bg: message.pinned ? 'highlight' : 'accentHover',
+          },
+          '&:hover .message-options': {
+            display: 'flex'
+          }
+        }}
+      >
+        {message.pinned ? pinnedMessage() : <></>}
+        <Flex alignItems="flex-start">
+          <Box
+            sx={{
+              minWidth: 'auto',
+            }}
+          >
+            <Gravatar email={message.user.email} size={32} style={{ borderRadius: '100%' }} />
+          </Box>
+
+          <Box
+            sx={{
+              hyphens: 'auto',
+              mx: 2,
+              width: '100%',
+            }}
+          >
+            <MessageHeader message={message} />
+            <Text
+              fontSize={2}
+              sx={{ whiteSpace: 'pre-line', overflowWrap: 'break-word', wordBreak: 'break-word', wordWrap: 'break-word' }}
+            >
+              {message.message}
+            </Text>
+          </Box>
+        </Flex>
+      </Box>
+    </>
   )
 }
 

--- a/src/Room/Message.tsx
+++ b/src/Room/Message.tsx
@@ -68,7 +68,7 @@ const PlayedAt: React.FC<PlayedAtProps> = ({ messageCreated, playedAt, song }) =
         fontWeight: '600',
         position: 'relative',
         '&:hover > *': {
-          visibility: 'visible'
+          visibility: 'visible',
         },
       }}
     >
@@ -155,13 +155,9 @@ const MessageHeader: React.FC<{ message: MessageType }> = ({ message }) => {
             width: '100%',
           }}
         >
-          <Box sx={{ color: 'text', fontWeight: '800' }}>
-            {message.user.name}
-          </Box>
+          <Box sx={{ color: 'text', fontWeight: '800' }}>{message.user.name}</Box>
 
-          <Box sx={{ color: 'gray500', fontSize: 1, fontWeight: '600', px: 2 }}>
-            {createdAt.format('ddd h:mm a')}
-          </Box>
+          <Box sx={{ color: 'gray500', fontSize: 1, fontWeight: '600', px: 2 }}>{createdAt.format('ddd h:mm a')}</Box>
           <PlayedAt messageCreated={createdAt} playedAt={playedAt} song={message.song} />
         </Text>
       </Flex>
@@ -170,7 +166,7 @@ const MessageHeader: React.FC<{ message: MessageType }> = ({ message }) => {
 }
 
 const Message: React.FC<{ message: MessageType }> = ({ message }) => {
-  const pinnedMessage = () => {
+  const PinnedMessage: React.FC = () => {
     return (
       <Flex
         sx={{
@@ -179,7 +175,9 @@ const Message: React.FC<{ message: MessageType }> = ({ message }) => {
         }}
       >
         <Star size={14} color="#5A67D8" fill="#5A67D8" />
-        <Text fontSize={1} mx={1}>Pinned!</Text>
+        <Text fontSize={1} mx={1}>
+          Pinned!
+        </Text>
       </Flex>
     )
   }
@@ -196,11 +194,11 @@ const Message: React.FC<{ message: MessageType }> = ({ message }) => {
             bg: message.pinned ? 'highlight' : 'accentHover',
           },
           '&:hover .message-options': {
-            display: 'flex'
-          }
+            display: 'flex',
+          },
         }}
       >
-        {message.pinned ? pinnedMessage() : <></>}
+        {message.pinned ? PinnedMessage : <></>}
         <Flex alignItems="flex-start">
           <Box
             sx={{
@@ -220,7 +218,12 @@ const Message: React.FC<{ message: MessageType }> = ({ message }) => {
             <MessageHeader message={message} />
             <Text
               fontSize={2}
-              sx={{ whiteSpace: 'pre-line', overflowWrap: 'break-word', wordBreak: 'break-word', wordWrap: 'break-word' }}
+              sx={{
+                whiteSpace: 'pre-line',
+                overflowWrap: 'break-word',
+                wordBreak: 'break-word',
+                wordWrap: 'break-word',
+              }}
             >
               {message.message}
             </Text>

--- a/src/Room/Message.tsx
+++ b/src/Room/Message.tsx
@@ -114,7 +114,6 @@ const MessageHeader: React.FC<{ message: MessageType }> = ({ message }) => {
   const playedAt = message.roomPlaylistRecord?.playedAt && moment(message.roomPlaylistRecord?.playedAt)
   const user = useUserContext()
   const showPin = user.id === message.user.id && !!message.song
-  console.log(message.pinned)
 
   return (
     <>
@@ -165,22 +164,26 @@ const MessageHeader: React.FC<{ message: MessageType }> = ({ message }) => {
   )
 }
 
-const Message: React.FC<{ message: MessageType }> = ({ message }) => {
-  const PinnedMessage: React.FC = () => {
-    return (
-      <Flex
-        sx={{
-          alignItems: 'center',
-          m: 2,
-        }}
-      >
-        <Star size={14} color="#5A67D8" fill="#5A67D8" />
-        <Text fontSize={1} mx={1}>
-          Pinned!
-        </Text>
-      </Flex>
-    )
+const PinnedMessage: React.FC<{ pinned: boolean }> = ({ pinned }) => {
+  if (!pinned) {
+    return <></>
   }
+  return (
+    <Flex
+      sx={{
+        alignItems: 'center',
+        m: 2,
+      }}
+    >
+      <Star size={14} color="#5A67D8" fill="#5A67D8" />
+      <Text fontSize={1} mx={1}>
+        Pinned!
+      </Text>
+    </Flex>
+  )
+}
+
+const Message: React.FC<{ message: MessageType }> = ({ message }) => {
   return (
     <>
       <Box
@@ -198,7 +201,7 @@ const Message: React.FC<{ message: MessageType }> = ({ message }) => {
           },
         }}
       >
-        {message.pinned ? PinnedMessage : <></>}
+        <PinnedMessage pinned={message.pinned} />
         <Flex alignItems="flex-start">
           <Box
             sx={{

--- a/src/Room/MessageEntry.tsx
+++ b/src/Room/MessageEntry.tsx
@@ -45,7 +45,7 @@ const MessageEntry: React.FC = () => {
   }
 
   return (
-    <Box>
+    <Box px={4}>
       <Textarea
         onChange={onChange}
         ref={textArea}

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -36,16 +36,51 @@ const MessageGroup: React.FC<{ messageGroup: MessageGroup }> = ({ messageGroup }
     <>
       <Box
         sx={{
-          borderBottomColor: 'text',
-          borderBottomWidth: 1,
-          borderBottomStyle: 'solid',
-          color: 'text',
-          mb: 2,
-          mx: 5,
-          textAlign: 'center',
+          my: 4,
+          position: 'relative',
+          '&:before': {
+            bg: 'accent',
+            content: "''",
+            height: '1px',
+            left: 0,
+            position: 'absolute',
+            top: '50%',
+            width: '25%',
+          },
+          '&:after': {
+            bg: 'accent',
+            content: "''",
+            height: '1px',
+            right: 0,
+            position: 'absolute',
+            top: '50%',
+            width: '25%',
+          }
         }}
       >
-        {songName || 'Nothing Playing'}
+        <Box
+          sx={{
+            bg: 'backgroundTint',
+            border: '1px solid',
+            borderColor: 'accent',
+            borderRadius: 6,
+            boxShadow: 'md',
+            color: 'gray500',
+            fontSize: 0,
+            fontWeight: 600,
+            overflow: 'hidden',
+            py: 2,
+            px: 3,
+            m: '0 auto',
+            textAlign: 'center',
+            textTransform: 'uppercase',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            width: '50%',
+          }}
+        >
+          {songName || 'No Song Playing'}
+        </Box>
       </Box>
       {messages.map(message => (
         <Message key={message.id} message={message} />
@@ -113,6 +148,7 @@ const Messages: React.FC = () => {
       ref={chat}
       sx={{
         overflowY: 'scroll',
+        py: 4
       }}
     >
       {messageLines}

--- a/src/Room/Messages.tsx
+++ b/src/Room/Messages.tsx
@@ -55,7 +55,7 @@ const MessageGroup: React.FC<{ messageGroup: MessageGroup }> = ({ messageGroup }
             position: 'absolute',
             top: '50%',
             width: '25%',
-          }
+          },
         }}
       >
         <Box
@@ -148,7 +148,7 @@ const Messages: React.FC = () => {
       ref={chat}
       sx={{
         overflowY: 'scroll',
-        py: 4
+        py: 4,
       }}
     >
       {messageLines}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,6 +7,8 @@ const colors = {
   formBorder: '#CBD5E0',
   primary: '#5A67D8', // primary button and link color
   secondary: '#4C51BF', // secondary color - can be used for hover states
+  accentHover: 'rgba(45, 55, 72, .3)',
+  highlight: 'rgba(90, 103, 216, .1)',
   modes: {
     light: {
       accent: '#718096',
@@ -17,14 +19,6 @@ const colors = {
       primary: '#5A67D8',
       secondary: '#4C51BF',
     },
-    // dark: {
-    //   text: '#fff',
-    //   background: '#000',
-    //   primary: '#0cf',
-    //   secondary: '#f0e',
-    //   gray: '#222',
-    //   lightgray: '#111',
-    // },
   },
   black: '#232323',
   blue: '#3182CE',


### PR DESCRIPTION
@go-between/folks 

Taking some heavy inspiration from slack here:

- updates style of "song banner" in the chat
- makes starred messages more noticeable 
- only shows the ability to star a message on hover
- adds hover styles
- tightens up spacing to make text more readable

![image](https://user-images.githubusercontent.com/1316075/77280199-af942200-6c91-11ea-8448-16d8d7eaba4b.png)
