### PR TITLE
[bugfix] Library scrolling bug

### DIFF
--- a/src/Library/Songs/Results.tsx
+++ b/src/Library/Songs/Results.tsx
@@ -100,8 +100,9 @@ const Songs: React.FC = () => {
       as="ul"
       sx={{
         m: 0,
-        p: 0,
         overflow: 'scroll',
+        p: 0,
+        position: 'relative',
       }}
     >
       {resultItems}

--- a/src/Library/Songs/index.tsx
+++ b/src/Library/Songs/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Flex } from 'rebass'
+import { Flex } from 'rebass'
 
 import Search from './Search'
 import Tags from './Tags'
@@ -18,9 +18,7 @@ const Songs: React.FC = () => {
     >
       <Search />
       <Tags />
-      <Box sx={{ maxHeight: '100vh', overflow: 'scroll' }}>
-        <Results />
-      </Box>
+      <Results />
     </Flex>
   )
 }


### PR DESCRIPTION
Some "light reading" leads me to believe that overflow doesn't seem to like it when it can find find a relative parent position. 