### PR TITLE
So seeeeeeeemless

### DIFF
--- a/src/Library/SongDetails/SongDetails.tsx
+++ b/src/Library/SongDetails/SongDetails.tsx
@@ -52,6 +52,7 @@ const SongDetails: React.FC = () => {
           height="100%"
           width="100%"
           style={{ display: 'flex' }}
+          controls={true}
         />
       </Flex>
 

--- a/src/Player/Player.tsx
+++ b/src/Player/Player.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Box, Flex, Text } from 'rebass'
+import { Box, Flex, Link, Text } from 'rebass'
 import Gravatar from 'react-gravatar'
+import { Youtube } from 'react-feather'
 
 import { useCurrentRecordContext } from 'Context'
 import { MediaObject } from 'components'
@@ -47,9 +48,15 @@ const Player: React.FC = () => {
 
         <Flex alignItems="center">
           <Progress />
-          <Volume />
           <Box mx={2} />
+          <Volume />
+          <Box mx={1} />
           <Settings />
+          <Box mx={2} />
+          <Link color="text" href={`https://youtube.com/watch?v=${currentRecord.song.youtubeId}`} target="_blank">
+            <Youtube />
+          </Link>
+          <Box mx={2} />
         </Flex>
         <Flex>
           <Approval />

--- a/src/Player/PlayerContextProvider.tsx
+++ b/src/Player/PlayerContextProvider.tsx
@@ -3,9 +3,6 @@ import React, { createContext, useContext, useState } from 'react'
 import { persistShowVideo, retrieveShowVideo } from 'lib/localStore'
 
 type PlayerContext = {
-  progress: number
-  playedSeconds: number
-  setProgress: (opts: { played: number; playedSeconds: number }) => void
   showVideo: boolean
   toggleShowVideo: () => void
 }
@@ -13,37 +10,21 @@ type PlayerContext = {
 const PlayerContext = createContext<Partial<PlayerContext>>({})
 export const PlayerContextProvider: React.FC = ({ children }) => {
   const [showVideo, setInnerShowVideo] = useState(retrieveShowVideo())
-  const [progress, setInnerProgress] = useState(0)
-  const [playedSeconds, setPlayedSeconds] = useState(0)
 
-  const setProgress = (opts: { played: number; playedSeconds: number }): void => {
-    setInnerProgress(opts.played * 100)
-    setPlayedSeconds(opts.playedSeconds)
-  }
   const toggleShowVideo = (): void => {
     persistShowVideo(!showVideo)
     setInnerShowVideo(!showVideo)
   }
 
-  return (
-    <PlayerContext.Provider value={{ progress, playedSeconds, setProgress, showVideo, toggleShowVideo }}>
-      {children}
-    </PlayerContext.Provider>
-  )
+  return <PlayerContext.Provider value={{ showVideo, toggleShowVideo }}>{children}</PlayerContext.Provider>
 }
 
 export const usePlayerContext: () => PlayerContext = () => {
-  const { progress, playedSeconds, setProgress, showVideo, toggleShowVideo } = useContext(PlayerContext)
+  const { showVideo, toggleShowVideo } = useContext(PlayerContext)
 
-  if (
-    progress === undefined ||
-    playedSeconds === undefined ||
-    setProgress === undefined ||
-    showVideo === undefined ||
-    toggleShowVideo === undefined
-  ) {
+  if (showVideo === undefined || toggleShowVideo === undefined) {
     throw new Error('PlayerContext accessed before being set')
   }
 
-  return { progress, playedSeconds, setProgress, showVideo, toggleShowVideo }
+  return { showVideo, toggleShowVideo }
 }

--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -48,9 +48,7 @@ const PlayerPrimitive: React.FC<Props> = ({ controls, inline = false, playedAt, 
 
   useEffect(() => {
     setVideoDimensions(videoRef?.current)
-  }, [videoRef])
 
-  useEffect(() => {
     const onResize = (): void => setVideoDimensions(videoRef?.current)
     window.addEventListener('resize', onResize)
 

--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { createPortal } from 'react-dom'
 import { Box } from 'rebass'
 import ReactPlayer from 'react-player'
 import moment from 'moment'
@@ -19,10 +18,11 @@ type Props = {
 
 const PlayerPrimitive: React.FC<Props> = ({ controls, inline = false, playedAt, youtubeId, playerIdentifier }) => {
   const [player, setPlayer] = useState<ReactPlayer>()
+  const [dimensions, setDimensions] = useState({ top: 0, right: 0, bottom: 0, left: 0 })
   const setRefFromPlayer = (player: ReactPlayer): void => setPlayer(player)
   const { unmutedPlayer, volume } = useVolumeContext()
   const { videoRef } = useVideoContext()
-  const { showVideo, setProgress } = usePlayerContext()
+  const { showVideo } = usePlayerContext()
 
   useEffect(() => {
     if (!player) {
@@ -36,34 +36,46 @@ const PlayerPrimitive: React.FC<Props> = ({ controls, inline = false, playedAt, 
     player.seekTo(start, 'seconds')
   }, [player, playedAt])
 
-  const Player = (
-    <ReactPlayer
-      ref={setRefFromPlayer}
-      controls={controls}
-      url={`https://www.youtube.com/watch?v=${youtubeId}&nonce=${playedAt}`}
-      playing={true}
-      progressInterval={500}
-      volume={unmutedPlayer === playerIdentifier ? (volume || 0) / 100.0 : 0}
-      height="350px"
-      width="100%"
-      style={{ border: '1px solid #2D3748' }}
-      onProgress={setProgress}
-    />
+  const setVideoDimensions = (ref: Element | undefined): void => {
+    if (!ref) {
+      return
+    }
+
+    const { top, bottom, left, width } = ref.getBoundingClientRect()
+    const right = window.innerWidth - left - width
+    setDimensions({ top, right, bottom, left })
+  }
+
+  useEffect(() => {
+    setVideoDimensions(videoRef?.current)
+  }, [videoRef])
+
+  useEffect(() => {
+    const onResize = (): void => setVideoDimensions(videoRef?.current)
+    window.addEventListener('resize', onResize)
+
+    return () => window.removeEventListener('resize', onResize)
+  }, [videoRef])
+
+  const position = inline || !videoRef ? 'inherit' : 'absolute'
+  const height = showVideo && videoRef ? 'auto' : '0'
+  const visibility = showVideo && videoRef ? 'visible' : 'hidden'
+  const { top, right, bottom, left } = dimensions
+
+  return (
+    <Box sx={{ position, top, right, bottom, left, height, visibility }}>
+      <ReactPlayer
+        ref={setRefFromPlayer}
+        controls={controls}
+        url={`https://www.youtube.com/watch?v=${youtubeId}&nonce=${playedAt}`}
+        playing={true}
+        volume={unmutedPlayer === playerIdentifier ? (volume || 0) / 100.0 : 0}
+        height="350px"
+        width="100%"
+        style={{ border: '1px solid #2D3748' }}
+      />
+    </Box>
   )
-
-  if (inline) {
-    return Player
-  }
-
-  if (!showVideo) {
-    return <Box sx={{ visibility: 'hidden', height: 0 }}>{Player}</Box>
-  }
-
-  if (!!videoRef && !!videoRef.current) {
-    return createPortal(Player, videoRef.current)
-  }
-
-  return <Box sx={{ visibility: 'hidden', height: 0 }}>{Player}</Box>
 }
 
 export default PlayerPrimitive

--- a/src/Player/Progress.tsx
+++ b/src/Player/Progress.tsx
@@ -1,14 +1,36 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box, Flex, Text } from 'rebass'
+import moment from 'moment'
 
 import { duration } from 'lib/formatters'
 import { useCurrentRecordContext } from 'Context'
 
-import { usePlayerContext } from './PlayerContextProvider'
-
 const Progress: React.FC = () => {
   const { currentRecord } = useCurrentRecordContext()
-  const { playedSeconds, progress } = usePlayerContext()
+  const [progress, setProgress] = useState(0)
+  const [playedSeconds, setPlayedSeconds] = useState(0)
+
+  useEffect(() => {
+    if (!currentRecord) {
+      return
+    }
+
+    const playedAt = moment(currentRecord.playedAt)
+    const endingAt = moment(currentRecord.playedAt).add(currentRecord.song.durationInSeconds, 'seconds')
+
+    const interval = setInterval(() => {
+      const now = moment()
+      const timeRemaining = endingAt.diff(now, 'seconds')
+      const percentPlayed = timeRemaining / currentRecord.song.durationInSeconds
+
+      const timePlayed = now.diff(playedAt, 'seconds')
+
+      setProgress((1 - percentPlayed) * 100)
+      setPlayedSeconds(timePlayed)
+    }, 500)
+
+    return () => clearInterval(interval)
+  }, [currentRecord])
 
   if (!currentRecord) {
     return <></>

--- a/src/QuickAdd/Results.tsx
+++ b/src/QuickAdd/Results.tsx
@@ -176,6 +176,7 @@ const FloatingResults: React.FC = ({ children }) => {
         overflow: 'scroll',
         px: 3,
         transition: 'all 2s ease-in',
+        zIndex: 10,
       }}
     >
       {children}

--- a/src/Room/Main.tsx
+++ b/src/Room/Main.tsx
@@ -19,12 +19,11 @@ const Main: React.FC<{ room: RoomType }> = ({ room }) => {
 
   // TODO:  Sort of a hack to ensure current record is set after room has
   // been activated.  This should be pulled out.
-  const { setCurrentRecord } = useCurrentRecordContext()
+  const { currentRecord, setCurrentRecord } = useCurrentRecordContext()
   const { setVideoRef } = useVideoContext()
-  const { currentRecord } = room
   useEffect(() => {
-    setCurrentRecord(currentRecord)
-  }, [currentRecord, setCurrentRecord])
+    setCurrentRecord(room.currentRecord)
+  }, [room, setCurrentRecord])
 
   const components: { [k: string]: React.FC } = {
     userPlaylist: UserPlaylist,
@@ -57,7 +56,19 @@ const Main: React.FC<{ room: RoomType }> = ({ room }) => {
           overflowY: 'scroll',
         }}
       >
-        <Box ref={videoRef} sx={{ bg: 'purple', height: '350px', width: '100%' }} />
+        <Flex
+          ref={videoRef}
+          sx={{
+            alignItems: 'center',
+            border: 'thin solid',
+            borderColor: 'primary',
+            height: '350px',
+            justifyContent: 'center',
+            width: '100%',
+          }}
+        >
+          <Text>{!!currentRecord ? 'Video Hidden' : 'Nothing Playing'}</Text>
+        </Flex>
 
         <Box
           sx={{

--- a/src/Room/Main.tsx
+++ b/src/Room/Main.tsx
@@ -33,7 +33,11 @@ const Main: React.FC<{ room: RoomType }> = ({ room }) => {
   }
   const Component = components[tab]
   const videoRef = useRef()
+
   setVideoRef(videoRef)
+  useEffect(() => {
+    return () => setVideoRef(null)
+  }, [setVideoRef])
 
   return (
     <Flex
@@ -53,7 +57,7 @@ const Main: React.FC<{ room: RoomType }> = ({ room }) => {
           overflowY: 'scroll',
         }}
       >
-        <Box ref={videoRef} />
+        <Box ref={videoRef} sx={{ bg: 'purple', height: '350px', width: '100%' }} />
 
         <Box
           sx={{


### PR DESCRIPTION
@go-between/folks 

pair: @DLavin23 

Some Quality of Life fixes:
  - Allows the main react player to always be rendered on the page and to find its home on the main room page via positioning instead of react portals (removes issue where the player rerenders and restarts when you navigate between room - library - recommendations)
  - Removes `onProgress` from the react player itself, instead allowing the `Progress` component to calculate its own offsets based on when the song started playing.  Removes issue where React was re-rendering the whole player every half second
  - Adds a youtube icon on the bottom bar with a link to the original song
  - Allows user controls on the song details view so you can skip around the video, although it will still play "on top" of any song playing currently in the main player rather than muting -- may fix this later.