### PR TITLE
[bugfix] library bugs

### DIFF
--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -61,7 +61,11 @@ const PlayerPrimitive: React.FC<Props> = ({ controls, inline = false, playedAt, 
   const { top, right, bottom, left } = dimensions
 
   return (
-    <Box sx={{ position, top, right, bottom, left, height, visibility }}>
+    <Box sx={{
+      position, top, right, bottom, left, height, visibility,
+      borderRadius: 6,
+      overflow: 'hidden',
+    }}>
       <ReactPlayer
         ref={setRefFromPlayer}
         controls={controls}
@@ -70,7 +74,7 @@ const PlayerPrimitive: React.FC<Props> = ({ controls, inline = false, playedAt, 
         volume={unmutedPlayer === playerIdentifier ? (volume || 0) / 100.0 : 0}
         height="350px"
         width="100%"
-        style={{ border: '1px solid #2D3748' }}
+        // style={{ borderRadius: '6px',  }}
       />
     </Box>
   )

--- a/src/Player/PlayerPrimitive.tsx
+++ b/src/Player/PlayerPrimitive.tsx
@@ -61,11 +61,19 @@ const PlayerPrimitive: React.FC<Props> = ({ controls, inline = false, playedAt, 
   const { top, right, bottom, left } = dimensions
 
   return (
-    <Box sx={{
-      position, top, right, bottom, left, height, visibility,
-      borderRadius: 6,
-      overflow: 'hidden',
-    }}>
+    <Box
+      sx={{
+        position,
+        top,
+        right,
+        bottom,
+        left,
+        height,
+        visibility,
+        borderRadius: 6,
+        overflow: 'hidden',
+      }}
+    >
       <ReactPlayer
         ref={setRefFromPlayer}
         controls={controls}

--- a/src/Room/Main.tsx
+++ b/src/Room/Main.tsx
@@ -60,8 +60,10 @@ const Main: React.FC<{ room: RoomType }> = ({ room }) => {
           ref={videoRef}
           sx={{
             alignItems: 'center',
-            border: 'thin solid',
-            borderColor: 'primary',
+            border: '1px solid',
+            borderColor: 'accent',
+            borderRadius: 6,
+            boxShadow: 'xl',
             height: '350px',
             justifyContent: 'center',
             width: '100%',

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -9,6 +9,7 @@ export const Table = styled('table')(
     borderSpacing: '0',
     m: 0,
     p: 0,
+    position: 'relative',
     tableLayout: ['fixed', 'auto', 'fixed'],
     width: '100%',
   }),


### PR DESCRIPTION
@go-between/folks 

Attempts to fix that weird library scrolling bug (https://github.com/go-between/musicbox/pull/83), yet again. I think it came back because position relative was applied to a `ul` element and we moved to a `table` element.

Also, our work from last night produced a new bug when you navigate to the library during a song. Look at all that extra space! 

![image](https://user-images.githubusercontent.com/1316075/82516661-fad77f00-9ae0-11ea-8254-853f5bab0d01.png)

This is because the container for our video has a fixed height of 350px, so even though it's "hidden" we still run into issues with the height. I used `overflow: hidden` to solve it for now.